### PR TITLE
Add rust to codegen and support for scalar type

### DIFF
--- a/lib/codegen/codegen.js
+++ b/lib/codegen/codegen.js
@@ -34,6 +34,7 @@ const JSONSchemaToConcertoVisitor = require(
     './fromJsonSchema/cto/jsonSchemaVisitor'
 );
 const OpenApiToConcertoVisitor = require('./fromOpenApi/cto/openApiVisitor');
+const RustVisitor = require('./fromcto/rust/rustvisitor');
 
 module.exports = {
     AbstractPlugin,
@@ -53,6 +54,7 @@ module.exports = {
     AvroVisitor,
     JSONSchemaToConcertoVisitor,
     OpenApiToConcertoVisitor,
+    RustVisitor,
     formats: {
         golang: GoLangVisitor,
         jsonschema: JSONSchemaVisitor,
@@ -68,5 +70,6 @@ module.exports = {
         protobuf: ProtobufVisitor,
         openapi: OpenApiVisitor,
         avro: AvroVisitor,
+        rust: RustVisitor
     }
 };

--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -35,7 +35,7 @@ const validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567
  *
  * @private
  * @class
- * @memberof module:concerto-tools
+ * @memberof module:concerto-codegen
  */
 class RustVisitor {
     /**
@@ -93,6 +93,8 @@ class RustVisitor {
             return this.visitRelationshipDeclaration(thing, parameters);
         } else if (thing.isEnumValue?.()) {
             return this.visitEnumValueDeclaration(thing, parameters);
+        } else if (thing.isScalarDeclaration?.()) {
+            return;
         } else {
             throw new Error('Unrecognised type: ' + typeof thing + ', value: ' + util.inspect(thing, { showHidden: true, depth: null }));
         }
@@ -205,7 +207,7 @@ class RustVisitor {
         }
 
         parameters.fileWriter.writeLine(1, '#[serde(');
-        parameters.fileWriter.writeLine(2, `rename = '${field.name}',`);
+        parameters.fileWriter.writeLine(2, `rename = "${field.name}",`);
         if (field.isOptional?.()) {
             parameters.fileWriter.writeLine(2, 'skip_serializing_if = "Option::is_none",');
             type = `Option<${type}>`;
@@ -271,7 +273,7 @@ class RustVisitor {
         if (relationshipDeclaration.isOptional?.()) {
             type = `Option<${type}>`;
         }
-        parameters.fileWriter.writeLine(1, `#[serde(rename = '${relationshipDeclaration.name}')]`);
+        parameters.fileWriter.writeLine(1, `#[serde(rename = "${relationshipDeclaration.name}")]`);
         parameters.fileWriter.writeLine(1, `pub ${this.toValidRustName(relationshipDeclaration.name.replace('$', ''))}: ${type},`);
         return null;
     }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -7510,6 +7510,1432 @@ message ChangeOfAddress {
 }
 `;
 
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'rust' 1`] = `
+{
+  "key": "mod.rs",
+  "value": "#[allow(unused_imports)]
+pub mod concerto_1_0_0;
+#[allow(unused_imports)]
+pub mod concerto;
+#[allow(unused_imports)]
+pub mod org_acme_hr;
+#[allow(unused_imports)]
+pub mod utils;
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'rust' 2`] = `
+{
+  "key": "utils.rs",
+  "value": "use chrono::{ DateTime, TimeZone, Utc };
+use serde::{ Deserialize, Serialize, Deserializer, Serializer };
+   
+pub fn serialize_datetime_option<S>(datetime: &Option<chrono::DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+   S: Serializer,
+{
+   match datetime {
+      Some(dt) => {
+         serialize_datetime(&dt, serializer)
+      },
+      _ => unreachable!(),
+   }
+}
+
+pub fn deserialize_datetime_option<'de, D>(deserializer: D) -> Result<Option<chrono::DateTime<Utc>>, D::Error>
+where
+   D: Deserializer<'de>,
+{
+   match deserialize_datetime(deserializer) {
+      Ok(result)=>Ok(Some(result)),
+      Err(error) => Err(error),
+   }
+}
+
+pub fn deserialize_datetime<'de, D>(deserializer: D) -> Result<chrono::DateTime<Utc>, D::Error>
+where
+   D: Deserializer<'de>,
+{
+   let datetime_str = String::deserialize(deserializer)?;
+   Utc.datetime_from_str(&datetime_str, "%Y-%m-%dT%H:%M:%S%.3f%Z").map_err(serde::de::Error::custom)
+}
+   
+pub fn serialize_datetime<S>(datetime: &chrono::DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+   S: Serializer,
+{
+   let datetime_str = datetime.format("%+").to_string();
+   serializer.serialize_str(&datetime_str)
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'rust' 3`] = `
+{
+  "key": "concerto_1_0_0.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Concept {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Asset {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Participant {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'rust' 4`] = `
+{
+  "key": "concerto.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Concept {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Asset {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Participant {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'rust' 5`] = `
+{
+  "key": "org_acme_hr.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::concerto_1_0_0::*;
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub enum State {
+   #[allow(non_camel_case_types)]
+   MA,
+   #[allow(non_camel_case_types)]
+   NY,
+   #[allow(non_camel_case_types)]
+   CO,
+   #[allow(non_camel_case_types)]
+   WA,
+   #[allow(non_camel_case_types)]
+   IL,
+   #[allow(non_camel_case_types)]
+   CA,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Address {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "street",
+   )]
+   pub street: String,
+   
+   #[serde(
+      rename = "city",
+   )]
+   pub city: String,
+   
+   #[serde(
+      rename = "state",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub state: Option<State>,
+   
+   #[serde(
+      rename = "zipCode",
+   )]
+   pub zip_code: String,
+   
+   #[serde(
+      rename = "country",
+   )]
+   pub country: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Company {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "name",
+   )]
+   pub name: String,
+   
+   #[serde(
+      rename = "headquarters",
+   )]
+   pub headquarters: Address,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Department {
+   #[allow(non_camel_case_types)]
+   Sales,
+   #[allow(non_camel_case_types)]
+   Marketing,
+   #[allow(non_camel_case_types)]
+   Finance,
+   #[allow(non_camel_case_types)]
+   HR,
+   #[allow(non_camel_case_types)]
+   Engineering,
+   #[allow(non_camel_case_types)]
+   Design,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Equipment {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "serialNumber",
+   )]
+   pub serial_number: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LaptopMake {
+   #[allow(non_camel_case_types)]
+   Apple,
+   #[allow(non_camel_case_types)]
+   Microsoft,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Laptop {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "make",
+   )]
+   pub make: LaptopMake,
+   
+   #[serde(
+      rename = "serialNumber",
+   )]
+   pub serial_number: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Person {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Employee {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "employeeId",
+   )]
+   pub employee_id: String,
+   
+   #[serde(
+      rename = "salary",
+   )]
+   pub salary: u64,
+   
+   #[serde(
+      rename = "numDependents",
+   )]
+   pub num_dependents: Integer,
+   
+   #[serde(
+      rename = "retired",
+   )]
+   pub retired: bool,
+   
+   #[serde(
+      rename = "department",
+   )]
+   pub department: Department,
+   
+   #[serde(
+      rename = "officeAddress",
+   )]
+   pub office_address: Address,
+   
+   #[serde(
+      rename = "companyAssets",
+   )]
+   pub company_assets: Vec<Equipment>,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Contractor {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "company",
+   )]
+   pub company: Company,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manager {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "reports")]
+   pub reports: Option<Vec<Person>>,
+   
+   #[serde(
+      rename = "employeeId",
+   )]
+   pub employee_id: String,
+   
+   #[serde(
+      rename = "salary",
+   )]
+   pub salary: u64,
+   
+   #[serde(
+      rename = "numDependents",
+   )]
+   pub num_dependents: Integer,
+   
+   #[serde(
+      rename = "retired",
+   )]
+   pub retired: bool,
+   
+   #[serde(
+      rename = "department",
+   )]
+   pub department: Department,
+   
+   #[serde(
+      rename = "officeAddress",
+   )]
+   pub office_address: Address,
+   
+   #[serde(
+      rename = "companyAssets",
+   )]
+   pub company_assets: Vec<Equipment>,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CompanyEvent {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Onboarded {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "employee")]
+   pub employee: Employee,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChangeOfAddress {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "Person")]
+   pub person: Person,
+   
+   #[serde(
+      rename = "newAddress",
+   )]
+   pub new_address: Address,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'rust' 1`] = `
+{
+  "key": "mod.rs",
+  "value": "#[allow(unused_imports)]
+pub mod concerto_1_0_0;
+#[allow(unused_imports)]
+pub mod concerto;
+#[allow(unused_imports)]
+pub mod org_acme_hr_1_0_0;
+#[allow(unused_imports)]
+pub mod utils;
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'rust' 2`] = `
+{
+  "key": "utils.rs",
+  "value": "use chrono::{ DateTime, TimeZone, Utc };
+use serde::{ Deserialize, Serialize, Deserializer, Serializer };
+   
+pub fn serialize_datetime_option<S>(datetime: &Option<chrono::DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+   S: Serializer,
+{
+   match datetime {
+      Some(dt) => {
+         serialize_datetime(&dt, serializer)
+      },
+      _ => unreachable!(),
+   }
+}
+
+pub fn deserialize_datetime_option<'de, D>(deserializer: D) -> Result<Option<chrono::DateTime<Utc>>, D::Error>
+where
+   D: Deserializer<'de>,
+{
+   match deserialize_datetime(deserializer) {
+      Ok(result)=>Ok(Some(result)),
+      Err(error) => Err(error),
+   }
+}
+
+pub fn deserialize_datetime<'de, D>(deserializer: D) -> Result<chrono::DateTime<Utc>, D::Error>
+where
+   D: Deserializer<'de>,
+{
+   let datetime_str = String::deserialize(deserializer)?;
+   Utc.datetime_from_str(&datetime_str, "%Y-%m-%dT%H:%M:%S%.3f%Z").map_err(serde::de::Error::custom)
+}
+   
+pub fn serialize_datetime<S>(datetime: &chrono::DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+   S: Serializer,
+{
+   let datetime_str = datetime.format("%+").to_string();
+   serializer.serialize_str(&datetime_str)
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'rust' 3`] = `
+{
+  "key": "concerto_1_0_0.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Concept {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Asset {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Participant {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'rust' 4`] = `
+{
+  "key": "concerto.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Concept {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Asset {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Participant {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'rust' 5`] = `
+{
+  "key": "org_acme_hr_1_0_0.rs",
+  "value": "use serde::{ Deserialize, Serialize };
+use chrono::{ DateTime, TimeZone, Utc };
+   
+use crate::concerto_1_0_0::*;
+use crate::utils::*;
+   
+#[derive(Debug, Serialize, Deserialize)]
+pub enum State {
+   #[allow(non_camel_case_types)]
+   MA,
+   #[allow(non_camel_case_types)]
+   NY,
+   #[allow(non_camel_case_types)]
+   CO,
+   #[allow(non_camel_case_types)]
+   WA,
+   #[allow(non_camel_case_types)]
+   IL,
+   #[allow(non_camel_case_types)]
+   CA,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Address {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "street",
+   )]
+   pub street: String,
+   
+   #[serde(
+      rename = "city",
+   )]
+   pub city: String,
+   
+   #[serde(
+      rename = "state",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub state: Option<State>,
+   
+   #[serde(
+      rename = "zipCode",
+   )]
+   pub zip_code: String,
+   
+   #[serde(
+      rename = "country",
+   )]
+   pub country: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Company {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "name",
+   )]
+   pub name: String,
+   
+   #[serde(
+      rename = "headquarters",
+   )]
+   pub headquarters: Address,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Department {
+   #[allow(non_camel_case_types)]
+   Sales,
+   #[allow(non_camel_case_types)]
+   Marketing,
+   #[allow(non_camel_case_types)]
+   Finance,
+   #[allow(non_camel_case_types)]
+   HR,
+   #[allow(non_camel_case_types)]
+   Engineering,
+   #[allow(non_camel_case_types)]
+   Design,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Equipment {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "serialNumber",
+   )]
+   pub serial_number: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LaptopMake {
+   #[allow(non_camel_case_types)]
+   Apple,
+   #[allow(non_camel_case_types)]
+   Microsoft,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Laptop {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "make",
+   )]
+   pub make: LaptopMake,
+   
+   #[serde(
+      rename = "serialNumber",
+   )]
+   pub serial_number: String,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Person {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Employee {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "employeeId",
+   )]
+   pub employee_id: String,
+   
+   #[serde(
+      rename = "salary",
+   )]
+   pub salary: u64,
+   
+   #[serde(
+      rename = "numDependents",
+   )]
+   pub num_dependents: Integer,
+   
+   #[serde(
+      rename = "retired",
+   )]
+   pub retired: bool,
+   
+   #[serde(
+      rename = "department",
+   )]
+   pub department: Department,
+   
+   #[serde(
+      rename = "officeAddress",
+   )]
+   pub office_address: Address,
+   
+   #[serde(
+      rename = "companyAssets",
+   )]
+   pub company_assets: Vec<Equipment>,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Contractor {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "company",
+   )]
+   pub company: Company,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manager {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "reports")]
+   pub reports: Option<Vec<Person>>,
+   
+   #[serde(
+      rename = "employeeId",
+   )]
+   pub employee_id: String,
+   
+   #[serde(
+      rename = "salary",
+   )]
+   pub salary: u64,
+   
+   #[serde(
+      rename = "numDependents",
+   )]
+   pub num_dependents: Integer,
+   
+   #[serde(
+      rename = "retired",
+   )]
+   pub retired: bool,
+   
+   #[serde(
+      rename = "department",
+   )]
+   pub department: Department,
+   
+   #[serde(
+      rename = "officeAddress",
+   )]
+   pub office_address: Address,
+   
+   #[serde(
+      rename = "companyAssets",
+   )]
+   pub company_assets: Vec<Equipment>,
+   
+   #[serde(rename = "manager")]
+   pub manager: Option<Manager>,
+   
+   #[serde(
+      rename = "email",
+   )]
+   pub email: String,
+   
+   #[serde(
+      rename = "firstName",
+   )]
+   pub first_name: String,
+   
+   #[serde(
+      rename = "lastName",
+   )]
+   pub last_name: String,
+   
+   #[serde(
+      rename = "middleNames",
+      skip_serializing_if = "Option::is_none",
+   )]
+   pub middle_names: Option<String>,
+   
+   #[serde(
+      rename = "homeAddress",
+   )]
+   pub home_address: Address,
+   
+   #[serde(
+      rename = "ssn",
+   )]
+   pub ssn: String,
+   
+   #[serde(
+      rename = "height",
+   )]
+   pub height: f64,
+   
+   #[serde(
+      rename = "dob",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub dob: DateTime<Utc>,
+   
+   #[serde(
+      rename = "$identifier",
+   )]
+   pub _identifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CompanyEvent {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Onboarded {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "employee")]
+   pub employee: Employee,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChangeOfAddress {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(rename = "Person")]
+   pub person: Person,
+   
+   #[serde(
+      rename = "newAddress",
+   )]
+   pub new_address: Address,
+   
+   #[serde(
+      rename = "$timestamp",
+      serialize_with = "serialize_datetime",
+      deserialize_with = "deserialize_datetime",
+   )]
+   pub _timestamp: DateTime<Utc>,
+}
+
+",
+}
+`;
+
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'typescript' 1`] = `
 {
   "key": "concerto@1.0.0.ts",

--- a/test/codegen/fromcto/rust/rustvisitor.js
+++ b/test/codegen/fromcto/rust/rustvisitor.js
@@ -322,7 +322,7 @@ describe('RustVisitor', function () {
                     1, '#[serde('
                 ],
                 [
-                    2, 'rename = \'$class\','
+                    2, 'rename = "$class",'
                 ],
                 [
                     1, ')]'
@@ -366,7 +366,7 @@ describe('RustVisitor', function () {
                     1, '#[serde('
                 ],
                 [
-                    2, 'rename = \'name\','
+                    2, 'rename = "name",'
                 ],
                 [
                     1, ')]'
@@ -400,7 +400,7 @@ describe('RustVisitor', function () {
                     1, '#[serde('
                 ],
                 [
-                    2, 'rename = \'Bob\','
+                    2, 'rename = "Bob",'
                 ],
                 [
                     1, ')]'
@@ -434,7 +434,7 @@ describe('RustVisitor', function () {
                     1, '#[serde('
                 ],
                 [
-                    2, 'rename = \'Bob\','
+                    2, 'rename = "Bob",'
                 ],
                 [
                     2, 'skip_serializing_if = "Option::is_none",'
@@ -471,7 +471,7 @@ describe('RustVisitor', function () {
                     1, '#[serde('
                 ],
                 [
-                    2, 'rename = \'timestamp\','
+                    2, 'rename = "timestamp",'
                 ],
                 [
                     2, 'serialize_with = "serialize_datetime",'
@@ -531,7 +531,7 @@ describe('RustVisitor', function () {
 
             param.fileWriter.writeLine.getCalls().map(call => call.args).should.deep.equal([
                 [
-                    1, '#[serde(rename = \'Bob\')]'
+                    1, '#[serde(rename = "Bob")]'
                 ],
                 [
                     1, 'pub bob: Person,'
@@ -550,7 +550,7 @@ describe('RustVisitor', function () {
 
             param.fileWriter.writeLine.getCalls().map(call => call.args).should.deep.equal([
                 [
-                    1, '#[serde(rename = \'Bob\')]'
+                    1, '#[serde(rename = "Bob")]'
                 ],
                 [
                     1, 'pub bob: Vec<Person>,'
@@ -569,7 +569,7 @@ describe('RustVisitor', function () {
 
             param.fileWriter.writeLine.getCalls().map(call => call.args).should.deep.equal([
                 [
-                    1, '#[serde(rename = \'Bob\')]'
+                    1, '#[serde(rename = "Bob")]'
                 ],
                 [
                     1, 'pub bob: Option<Person>,'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ export var CodeGen: {
     AvroVisitor: typeof import("./lib/codegen/fromcto/avro/avrovisitor");
     JSONSchemaToConcertoVisitor: typeof import("./lib/codegen/fromJsonSchema/cto/jsonSchemaVisitor");
     OpenApiToConcertoVisitor: typeof import("./lib/codegen/fromOpenApi/cto/openApiVisitor");
+    RustVisitor: typeof import("./lib/codegen/fromcto/rust/rustvisitor");
     formats: {
         golang: typeof import("./lib/codegen/fromcto/golang/golangvisitor");
         jsonschema: typeof import("./lib/codegen/fromcto/jsonschema/jsonschemavisitor");
@@ -31,6 +32,7 @@ export var CodeGen: {
         protobuf: typeof import("./lib/codegen/fromcto/protobuf/protobufvisitor");
         openapi: typeof import("./lib/codegen/fromcto/openapi/openapivisitor");
         avro: typeof import("./lib/codegen/fromcto/avro/avrovisitor");
+        rust: typeof import("./lib/codegen/fromcto/rust/rustvisitor");
     };
 };
 export var Common: typeof import("./lib/common/common");

--- a/types/lib/codegen/codegen.d.ts
+++ b/types/lib/codegen/codegen.d.ts
@@ -15,6 +15,8 @@ import OpenApiVisitor = require("./fromcto/openapi/openapivisitor");
 import AvroVisitor = require("./fromcto/avro/avrovisitor");
 import JSONSchemaToConcertoVisitor = require("./fromJsonSchema/cto/jsonSchemaVisitor");
 import OpenApiToConcertoVisitor = require("./fromOpenApi/cto/openApiVisitor");
+import RustVisitor = require("./fromcto/rust/rustvisitor");
+
 export declare namespace formats {
     export { GoLangVisitor as golang };
     export { JSONSchemaVisitor as jsonschema };
@@ -30,5 +32,6 @@ export declare namespace formats {
     export { ProtobufVisitor as protobuf };
     export { OpenApiVisitor as openapi };
     export { AvroVisitor as avro };
+    export { RustVisitor as rust };
 }
-export { AbstractPlugin, GoLangVisitor, JSONSchemaVisitor, XmlSchemaVisitor, PlantUMLVisitor, TypescriptVisitor, JavaVisitor, GraphQLVisitor, CSharpVisitor, ODataVisitor, MermaidVisitor, MarkdownVisitor, ProtobufVisitor, OpenApiVisitor, AvroVisitor, JSONSchemaToConcertoVisitor, OpenApiToConcertoVisitor };
+export { AbstractPlugin, GoLangVisitor, JSONSchemaVisitor, XmlSchemaVisitor, PlantUMLVisitor, TypescriptVisitor, JavaVisitor, GraphQLVisitor, CSharpVisitor, ODataVisitor, MermaidVisitor, MarkdownVisitor, ProtobufVisitor, OpenApiVisitor, AvroVisitor, JSONSchemaToConcertoVisitor, OpenApiToConcertoVisitor, RustVisitor };

--- a/types/lib/codegen/fromcto/rust/rustvisitor.d.ts
+++ b/types/lib/codegen/fromcto/rust/rustvisitor.d.ts
@@ -1,0 +1,102 @@
+export = RustVisitor;
+/**
+ * Convert the contents of a ModelManager to Rust code.
+ * All generated code is placed into the 'main' package. Set a
+ * fileWriter property (instance of FileWriter) on the parameters
+ * object to control where the generated code is written to disk.
+ *
+ * @private
+ * @class
+ * @memberof module:concerto-codegen
+ */
+declare class RustVisitor {
+    /**
+     * Visitor design pattern
+     * @param {Object} thing - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @public
+     */
+    public visit(thing: any, parameters: any): any;
+    /**
+     * Visitor design pattern
+     * @param {ModelManager} modelManager - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitModelManager;
+    /**
+     * Visitor design pattern
+     * @param {ModelFile} modelFile - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitModelFile;
+    /**
+     * Visitor design pattern
+     * @param {EnumDeclaration} enumDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitEnumDeclaration;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitClassDeclaration;
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitField;
+    /**
+     * Visitor design pattern
+     * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitEnumValueDeclaration;
+    /**
+     * Visitor design pattern
+     * @param {Relationship} relationship - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitRelationshipDeclaration;
+    /**
+     * Converts a Concerto type to a Rust  type. Primitive types are converted
+     * everything else is passed through unchanged.
+     * @param {string} type  - the concerto type
+     * @return {string} the corresponding type in Rust
+     * @private
+     */
+    private toRustType;
+
+    /**
+     * Converts a Concerto field name to a Rust field name.
+     * everything else is passed through unchanged.
+     * @param {string} name  - the concerto field name
+     * @return {string} the corresponding name in Rust
+     * @private
+     */
+    private toValidRustName;
+
+    /**
+     * Generates utils file to handle date serialize and de-serialize.
+     * everything else is passed through unchanged.
+     * @param {Object} parameters  - the parameter
+     * @private
+     */
+    private addUtilsModelFile;
+}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Adds rust visitor to codegen
- <TWO> updates codegen snapshot with rust snapshot to be able to generate rust code
- <THREE> Adds support for scalar field
- <FOUR> replaces single quote with double quote for consistency fixes test against this change

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
