### PR TITLE
fix(tools): Add dummy classes to dotnet gen models to avoid compilation errors

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -73,7 +73,7 @@ class CSharpVisitor {
         } else if (thing.isEnumValue?.()) {
             return this.visitEnumValueDeclaration(thing, parameters);
         } else if (thing.isScalarDeclaration?.()) {
-            return;
+            return this.visitScalarDeclarationField(thing, parameters);
         } else {
             throw new Error('Unrecognised type: ' + typeof thing + ', value: ' + util.inspect(thing, {
                 showHidden: true,
@@ -124,7 +124,6 @@ class CSharpVisitor {
         modelFile.getImports()
             .map(importString => ModelUtil.getNamespace(importString))
             .filter(namespace => namespace !== modelFile.getNamespace()) // Skip own namespace.
-            .filter(namespace => !namespace.startsWith('concerto.scalar')) // Skip concerto.scalar namespace.
             .filter((v, i, a) => a.indexOf(v) === i) // Remove any duplicates from direct imports
             .forEach(namespace => {
                 const otherModelFile = modelFile.getModelManager()?.getModelFile(namespace);
@@ -233,6 +232,19 @@ class CSharpVisitor {
             property.accept(this, parameters);
         });
         parameters.fileWriter.writeLine(0, '}');
+        return null;
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitScalarDeclarationField(scalarDeclaration, parameters) {
+        parameters.fileWriter.writeLine(0, '//Dummy implementation of the scalar declaration to avoid compilation errors.');
+        parameters.fileWriter.writeLine(0, `class ${scalarDeclaration.getName()}_Dummy {}`);
         return null;
     }
 

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -124,6 +124,7 @@ class CSharpVisitor {
         modelFile.getImports()
             .map(importString => ModelUtil.getNamespace(importString))
             .filter(namespace => namespace !== modelFile.getNamespace()) // Skip own namespace.
+            .filter(namespace => !namespace.startsWith('concerto.scalar')) // Skip concerto.scalar namespace.
             .filter((v, i, a) => a.indexOf(v) === i) // Remove any duplicates from direct imports
             .forEach(namespace => {
                 const otherModelFile = modelFile.getModelManager()?.getModelFile(namespace);

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -359,6 +359,8 @@ public class Laptop : Equipment {
    public override string _class { get; } = "org.acme.hr.Laptop";
    public LaptopMake make { get; set; }
 }
+//Dummy implementation of the scalar declaration to avoid compilation errors.
+class SSN_Dummy {}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Person")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public abstract class Person : Participant {
@@ -4474,6 +4476,8 @@ public class Laptop : Equipment {
    public override string _class { get; } = "org.acme.hr@1.0.0.Laptop";
    public LaptopMake make { get; set; }
 }
+//Dummy implementation of the scalar declaration to avoid compilation errors.
+class SSN_Dummy {}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Person")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public abstract class Person : Participant {

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -346,10 +346,13 @@ describe('CSharpVisitor', function () {
             const files = fileWriter.getFilesInMemory();
             const file1 = files.get('org.acme@1.2.3.cs');
             file1.should.match(/namespace org.acme;/);
-            file1.should.not.match(/using concerto.scalar;/);
+            file1.should.match(/using concerto.scalar;/);
             file1.should.match(/class Thing/);
             file1.should.match(/public System.Guid ThingId/);
             file1.should.match(/public System.Guid\? SomeOtherId/);
+
+            const file2 = files.get('concerto.scalar@1.0.0.cs');
+            file2.should.match(/class UUID_Dummy {}/);
         });
 
         it('should use regex annotation when regex pattern provided to a field', () => {
@@ -399,8 +402,12 @@ public class AgreementBase : Concept {
             const files = fileWriter.getFilesInMemory();
             const file1 = files.get('org.acme@1.2.3.cs');
             file1.should.match(/namespace org.acme;/);
+            file1.should.match(/using org.specific.scalar;/);
             file1.should.match(/class Thing/);
             file1.should.match(/public string ThingId/);
+
+            const file2 = files.get('org.specific.scalar@1.0.0.cs');
+            file2.should.match(/class UUID_Dummy {}/);
         });
 
         it('should use string for scalar type non UUID', () => {
@@ -427,6 +434,9 @@ public class AgreementBase : Concept {
             file1.should.match(/class Thing/);
             file1.should.match(/public string ThingId/);
             file1.should.match(/public string\? SomeOtherId/);
+
+            const file2 = files.get('concerto.scalar@1.0.0.cs');
+            file2.should.match(/class SSN_Dummy {}/);
         });
 
         it('should use the @AcceptedValue decorator if present', () => {

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -346,6 +346,7 @@ describe('CSharpVisitor', function () {
             const files = fileWriter.getFilesInMemory();
             const file1 = files.get('org.acme@1.2.3.cs');
             file1.should.match(/namespace org.acme;/);
+            file1.should.not.match(/using concerto.scalar;/);
             file1.should.match(/class Thing/);
             file1.should.match(/public System.Guid ThingId/);
             file1.should.match(/public System.Guid\? SomeOtherId/);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Description
The 'concerto.scalar.uuid' namespace is automatically added to the .NET models if the CTO file has a property of type UUID. However, since we treat UUID in CTO as 'System.Guid' in .NET, there is no need to add an import namespace to the generated .NET file.

Adding this namespace resulting in build failures in .NET, so update csharp codegen to ignore adding this namespace to .net models. So excluding the concerto scalar namespace in dotnet generated models.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
