### PR TITLE
fix(jsonschema): fix bug with inference from JSON Schema

### DIFF
--- a/lib/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
+++ b/lib/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
@@ -144,7 +144,8 @@ class JsonSchemaVisitor {
         return referenceString
             .slice(1, referenceString.length)
             .split('/')
-            .filter(pathSegment => pathSegment.length > 0);
+            .filter(pathSegment => pathSegment.length > 0)
+            .map(pathSegment => decodeURI(pathSegment));
     }
     /**
      * Parse a $id URL to use it as a namespace and root type.
@@ -326,6 +327,31 @@ class JsonSchemaVisitor {
                 ...this.inferTypeSpecificValidator(property, metaModelNamespace)
             };
         }
+    }
+    /**
+     * Deduplicate a list of declarations by name. Duplicated declarations often
+     * occur when we're traversing through multiple definitions that are
+     * ultimately referencing the same object.
+     * @param {Array<Object>} declarations - list of declarations with possible
+     * duplicates.
+     *
+     * @return {Array<Object>} list of declarations without duplicates.
+     * @private
+     */
+    deduplicateDeclarations(declarations) {
+        const uniqueDeclarationsNames = [
+            ...new Set(
+                declarations.map(
+                    declaration => declaration.name
+                )
+            )
+        ];
+
+        return uniqueDeclarationsNames.map(
+            uniqueDeclarationsName => declarations.find(
+                declaration => declaration.name === uniqueDeclarationsName
+            )
+        );
     }
     /**
      * Local reference property visitor.
@@ -630,6 +656,14 @@ class JsonSchemaVisitor {
      * @private
      */
     visitNonEnumDefinition(nonEnumDefinition, parameters) {
+        if (this.isReference(nonEnumDefinition)) {
+            return (
+                new Reference(
+                    nonEnumDefinition.body.$ref, nonEnumDefinition.path
+                )
+            ).accept(this, parameters);
+        }
+
         const nameOfDefinition = this.normalizeName(
             nonEnumDefinition.path[
                 nonEnumDefinition.path.length - 1
@@ -762,7 +796,7 @@ class JsonSchemaVisitor {
      * @private
      */
     visitDefinition(definition, parameters) {
-        if (typeof definition.body.enum === 'object') {
+        if (typeof definition.body?.enum === 'object') {
             return (
                 new EnumDefinition(definition.body, definition.path)
             ).accept(this, parameters);
@@ -877,7 +911,7 @@ class JsonSchemaVisitor {
             decorators: [],
             namespace: parameters.namespace,
             imports: [],
-            declarations,
+            declarations: this.deduplicateDeclarations(declarations),
         };
 
         const concertoJsonModel = {

--- a/test/codegen/fromJsonSchema/cto/data/jsonSchemaFromTypescriptShapes.json
+++ b/test/codegen/fromJsonSchema/cto/data/jsonSchemaFromTypescriptShapes.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/DataIOWriteDataByUri",
+    "definitions": {
+        "DataIOWriteDataByUri": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "const": "Contracts.Actions.DataIO.Version3.WriteDataByUri"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "action"
+                },
+                "input": {
+                    "$ref": "#/definitions/ActionContractSchema%3CActionContractSchema%3Calias-969551601-132-307-969551601-0-1080360522385%3E%3E"
+                },
+                "output": {
+                    "$ref": "#/definitions/ActionContractSchema%3CActionContractSchema%3Calias-969551601-307-463-969551601-0-10801928584726%3E%3E"
+                }
+            },
+            "required": [
+                "input",
+                "name",
+                "output",
+                "type"
+            ],
+            "additionalProperties": false,
+            "description": "This action contract handles writing data to a specific URI"
+        },
+        "ActionContractSchema<ActionContractSchema<alias-969551601-132-307-969551601-0-1080360522385>>": {
+            "$ref": "#/definitions/ActionContractSchema%3Calias-969551601-132-307-969551601-0-1080360522385%3E",
+            "description": "Action Contract Schema"
+        },
+        "ActionContractSchema<alias-969551601-132-307-969551601-0-1080360522385>": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uri": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "uri"
+            ],
+            "description": "Action Contract Schema"
+        },
+        "ActionContractSchema<ActionContractSchema<alias-969551601-307-463-969551601-0-10801928584726>>": {
+            "$ref": "#/definitions/ActionContractSchema%3Calias-969551601-307-463-969551601-0-10801928584726%3E",
+            "description": "Action Contract Schema"
+        },
+        "ActionContractSchema<alias-969551601-307-463-969551601-0-10801928584726>": {
+            "$ref": "#/definitions/ActionContractSchema%3CActionContractSchema%3Calias-893869671-313-536-893869671-0-10591185408304%3E%3E",
+            "description": "Action Contract Schema"
+        },
+        "ActionContractSchema<ActionContractSchema<alias-893869671-313-536-893869671-0-10591185408304>>": {
+            "$ref": "#/definitions/ActionContractSchema%3Calias-893869671-313-536-893869671-0-10591185408304%3E",
+            "description": "Action Contract Schema"
+        },
+        "ActionContractSchema<alias-893869671-313-536-893869671-0-10591185408304>": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "additionalProperties": false,
+            "description": "Action Contract Schema"
+        }
+    }
+}

--- a/test/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
+++ b/test/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
@@ -406,4 +406,42 @@ concept Foo {
 
         inferredConcertoModel.should.equal('namespace com.test@1.0.0');
     });
+
+    it('should generate Concerto for for a JSON schema generated from TypeScript shapes', async () => {
+        const schema = JSON.parse(
+            fs.readFileSync(
+                path.resolve(__dirname, '../cto/data/jsonSchemaFromTypescriptShapes.json'), 'utf8'
+            )
+        );
+
+        const inferredConcertoJsonModel = JsonSchemaVisitor
+            .parse(schema)
+            .accept(
+                jsonSchemaVisitor,
+                jsonSchemaVisitorParameters,
+            );
+
+        const inferredConcertoModel = Printer.toCTO(
+            inferredConcertoJsonModel.models[0]
+        );
+
+        inferredConcertoModel.should.equal(`namespace com.test@1.0.0
+
+concept DataIOWriteDataByUri {
+  o String name
+  o String type
+  o ActionContractSchema_alias_969551601_132_307_969551601_0_1080360522385_ input
+  o ActionContractSchema_alias_893869671_313_536_893869671_0_10591185408304_ output
+}
+
+concept ActionContractSchema_alias_969551601_132_307_969551601_0_1080360522385_ {
+  o String uri
+  @StringifiedJson
+  o String data
+}
+
+concept ActionContractSchema_alias_893869671_313_536_893869671_0_10591185408304_ {
+  o String id
+}`);
+    });
 });


### PR DESCRIPTION
# Closes #16

Fixes bug when inferring Concerto from JSON Schema.

### Changes
- URL-encoded references get decoded.
- References in definitions' bodies get handled.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
