### PR TITLE
fix(*):fix concept name conflict with dependent namespaces

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -195,7 +195,8 @@ class CSharpVisitor {
         if (classDeclaration.getSuperType()) {
             const superTypeName = ModelUtil.getShortName(classDeclaration.getSuperType());
             const superTypeIdentifier = this.toCSharpIdentifier(undefined, superTypeName, parameters);
-            superType = ` : ${superTypeIdentifier} `;
+            let fqn = this.getDotNetNamespaceOfType(classDeclaration.getSuperType(), classDeclaration, parameters);
+            superType = ` : ${fqn}${superTypeIdentifier} `;
         }
 
         let abstract = '';
@@ -233,6 +234,39 @@ class CSharpVisitor {
         });
         parameters.fileWriter.writeLine(0, '}');
         return null;
+    }
+
+    /**
+     * Get dotnet namespace of a given type if it belongs to different namespace from associated concept/class
+     * @param {string} type name of the super type
+     * @param {ClassDeclaration} classDeclaration of the class
+     * @param {Object} parameters - the parameter
+     * @returns {string} the dotnet namespace of given type
+     * @private
+     */
+    getDotNetNamespaceOfType(type, classDeclaration, parameters) {
+        let dotnetNs = '';
+        // Resolve to dotnet namespace only if its a non system type
+        if (type &&  ModelUtil.parseNamespace(ModelUtil.getNamespace(type)).name !== 'concerto') {
+            const mm = classDeclaration.getModelFile()?.getModelManager();
+            let typeNamespace = mm?.getType(type)?.getNamespace();
+            if (typeNamespace && typeNamespace !== classDeclaration.getNamespace()) {
+                // Ensure non-empty string, that is separated by a period
+                let namespacePrefix = parameters.namespacePrefix ? parameters.namespacePrefix : '';
+                if (namespacePrefix !== '' && namespacePrefix.slice(-1) !== '.') {
+                    namespacePrefix += '.';
+                }
+                const otherModelFile = mm?.getModelFile(typeNamespace);
+                if (!otherModelFile) {
+                    // Couldn't resolve the other model file.
+                    dotnetNs = `${namespacePrefix}${typeNamespace}`;
+                } else {
+                    dotnetNs = this.getDotNetNamespace(otherModelFile, { ...parameters, namespacePrefix });
+                }
+                dotnetNs += '.';
+            }
+        }
+        return dotnetNs;
     }
 
     /**
@@ -315,6 +349,9 @@ class CSharpVisitor {
                     parameters.fileWriter.writeLine(1, `[System.ComponentModel.DataAnnotations.RegularExpression(@"${regexVal}", ErrorMessage = "Invalid characters")]`);
                 }
             }
+        } else if (!field.isPrimitive()) {
+            let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
+            fieldType = `${fqn}${fieldType}`;
         }
 
         let nullableType = '';

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -256,13 +256,8 @@ class CSharpVisitor {
                 if (namespacePrefix !== '' && namespacePrefix.slice(-1) !== '.') {
                     namespacePrefix += '.';
                 }
-                const otherModelFile = mm?.getModelFile(typeNamespace);
-                if (!otherModelFile) {
-                    // Couldn't resolve the other model file.
-                    dotnetNs = `${namespacePrefix}${typeNamespace}`;
-                } else {
-                    dotnetNs = this.getDotNetNamespace(otherModelFile, { ...parameters, namespacePrefix });
-                }
+                const otherModelFile = mm.getModelFile(typeNamespace);
+                dotnetNs = this.getDotNetNamespace(otherModelFile, { ...parameters, namespacePrefix });
                 dotnetNs += '.';
             }
         }


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes https://github.com/accordproject/concerto-codegen/issues/15
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
dotnet codegenerated models fail to compile when concept names conflict with dependent projects/namespaces.

### Solution
Resolve parent type/property type with fully qualified name if its imported from different model/namespace
```
namespace org.acme.other@2.3.4

concept OtherThing {
    o String id
}
```
```
namespace org.acme@1.2.3

import org.acme.other@2.3.4.{ OtherThing }

concept Thing extends OtherThing {
    o String someid
}

concept ThingTwo {
   o OtherThing otherThing
}

concept ThingThree extends Thing {
  o String name
}
```

Should get translated csharp gen code like below (for readability, I removed few concerto annotations in this example)

```
namespace org.acme;
using org.acme.other;
using AccordProject.Concerto;

public class Thing : Concept {
   public override string _class { get; } = "org.acme@1.2.3.Thing";

   // Resolve fully qualified namespace
   public org.acme.other.OtherThing otherThing { get; set; }
}

// Resolve fully qualified namespace
public class SomeOtherThing : org.acme.other.OtherThing {
   public override string _class { get; } = "org.acme@1.2.3.SomeOtherThing";
   public string someId { get; set; }
}
public class SameThing : Thing {
   public override string _class { get; } = "org.acme@1.2.3.SameThing";
   public string id { get; set; }
}
public class OneMoreThing : Concept {
   public override string _class { get; } = "org.acme@1.2.3.OneMoreThing";
   public string oneMoreThingId { get; set; }
   public Thing thing { get; set; }
}
```



### Related Issues
- Issue #https://github.com/accordproject/concerto-codegen/issues/15

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
