### PR TITLE
fix(*): pascal casing fix to resolve fqn

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -473,14 +473,7 @@ class CSharpVisitor {
      * @private
      */
     toCSharpNamespace(ns, parameters) {
-        const components = ns.split('.');
-        return components.map(component => {
-            if (parameters?.pascalCase) {
-                return camelCase(component, { pascalCase: true });
-            } else {
-                return component;
-            }
-        }).join('.');
+        return this.toCase(ns, parameters?.pascalCase);
     }
 
     /**
@@ -505,7 +498,7 @@ class CSharpVisitor {
 
         // Apply pascal casing.
         if(parameters?.pascalCase) {
-            name = camelCase(name, { pascalCase: true });
+            name = this.toCase(name, true);
         // Ensure name isn't a reserved keyword.
         } else if(reservedKeywords.includes(name)) {
             underscore = true;
@@ -621,6 +614,24 @@ class CSharpVisitor {
             return args[0];
         }
         return null;
+    }
+
+    /**
+     * Apply proper casing to the string value
+     * @param {string} string value
+     * @param {boolean} isPascalCase flag to converto to pascal case
+     * @returns {String} properly cased string value
+     * @private
+     */
+    toCase(string, isPascalCase) {
+        const components = string.split('.');
+        return components.map(component => {
+            if (isPascalCase) {
+                return camelCase(component, { pascalCase: true });
+            } else {
+                return component;
+            }
+        }).join('.');
     }
 }
 

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -619,7 +619,7 @@ class CSharpVisitor {
     /**
      * Apply proper casing to the string value
      * @param {string} string value
-     * @param {boolean} isPascalCase flag to converto to pascal case
+     * @param {boolean} isPascalCase flag to convert to pascalCase
      * @returns {String} properly cased string value
      * @private
      */


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes 
<!--- Provide an overall summary of the pull request -->

### Changes
When pascalCase is set to true, fully qualified name of a property removes the separators like `.-_` is removed from fully qualified name of a property.
This is causing the problem when we try to use fqn for a property to avoid type conflicts as reported in this issue https://github.com/accordproject/concerto-codegen/issues/15

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
