### PR TITLE
fix(browser) : package.json bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "npm": ">=6"
     },
     "main": "index.js",
-    "browser": "dist/concerto-codegen.js",
+    "browser": "umd/concerto-codegen.js",
     "typings": "types/index.d.ts",
     "scripts": {
         "coverage": "node ./scripts/coverage.js \"packages/concerto-*\" && nyc report -t coverage --cwd . --report-dir coverage --reporter=lcov && cat ./coverage/lcov.info",


### PR DESCRIPTION
# Closes #40

Fixes browser entry point in package.json to align with webpack config.

See https://github.com/accordproject/concerto-codegen/blob/e37980bf3458bb8597287899874c518963e49504/webpack.config.js#L28

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
