### PR TITLE
fix(csharp):remove semicolon (;) from map property declaration

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -316,7 +316,7 @@ class CSharpVisitor {
         // write Map field
         if ( Object.keys(field).length > 0 && ModelUtil.isMap?.(field)) {
             const decl = field.getModelFile().getAllDeclarations().find(d => d.name === field.ast.type.name);
-            parameters.fileWriter.writeLine(0, `public Dictionary<string, ${this.toCSharpType(decl.getValue().getType())}> ${field.getName()} { get; set; };\n`);
+            parameters.fileWriter.writeLine(1, `public Dictionary<string, ${this.toCSharpType(decl.getValue().getType())}> ${field.getName()} { get; set; }`);
             return null;
         }
 

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -327,18 +327,12 @@ public class Address : Concept {
    public State? state { get; set; }
    public string zipCode { get; set; }
    public string country { get; set; }
-public Dictionary<string, string> dictionary1 { get; set; };
-
-public Dictionary<string, System.DateTime> dictionary2 { get; set; };
-
-public Dictionary<string, SSN> dictionary3 { get; set; };
-
-public Dictionary<string, Concept> dictionary4 { get; set; };
-
-public Dictionary<string, string> dictionary5 { get; set; };
-
-public Dictionary<string, Employee> dictionary6 { get; set; };
-
+   public Dictionary<string, string> dictionary1 { get; set; }
+   public Dictionary<string, System.DateTime> dictionary2 { get; set; }
+   public Dictionary<string, SSN> dictionary3 { get; set; }
+   public Dictionary<string, Concept> dictionary4 { get; set; }
+   public Dictionary<string, string> dictionary5 { get; set; }
+   public Dictionary<string, Employee> dictionary6 { get; set; }
 }
 //Dummy implementation of the scalar declaration to avoid compilation errors.
 class Time_Dummy {}
@@ -5459,18 +5453,12 @@ public class Address : Concept {
    public State? state { get; set; }
    public string zipCode { get; set; }
    public string country { get; set; }
-public Dictionary<string, string> dictionary1 { get; set; };
-
-public Dictionary<string, System.DateTime> dictionary2 { get; set; };
-
-public Dictionary<string, SSN> dictionary3 { get; set; };
-
-public Dictionary<string, Concept> dictionary4 { get; set; };
-
-public Dictionary<string, string> dictionary5 { get; set; };
-
-public Dictionary<string, Employee> dictionary6 { get; set; };
-
+   public Dictionary<string, string> dictionary1 { get; set; }
+   public Dictionary<string, System.DateTime> dictionary2 { get; set; }
+   public Dictionary<string, SSN> dictionary3 { get; set; }
+   public Dictionary<string, Concept> dictionary4 { get; set; }
+   public Dictionary<string, string> dictionary5 { get; set; }
+   public Dictionary<string, Employee> dictionary6 { get; set; }
 }
 //Dummy implementation of the scalar declaration to avoid compilation errors.
 class Time_Dummy {}

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -1525,7 +1525,7 @@ public class SampleModel : Concept {
             mockMapDeclaration.getValue.returns({ getType: getValueType });
 
             csharpVisitor.visitField(mockField, param);
-            param.fileWriter.writeLine.withArgs(0, 'public Dictionary<string, string> Map1 { get; set; };\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public Dictionary<string, string> Map1 { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for field name and type thats a map of <String, Concept>', () => {
@@ -1551,7 +1551,7 @@ public class SampleModel : Concept {
             mockMapDeclaration.getValue.returns({ getType: getValueType });
 
             csharpVisitor.visitField(mockField, param);
-            param.fileWriter.writeLine.withArgs(0, 'public Dictionary<string, Concept> Map1 { get; set; };\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public Dictionary<string, Concept> Map1 { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for field name and type thats a map of <String, DateTime>', () => {
@@ -1577,7 +1577,7 @@ public class SampleModel : Concept {
             mockMapDeclaration.getValue.returns({ getType: getValueType });
 
             csharpVisitor.visitField(mockField, param);
-            param.fileWriter.writeLine.withArgs(0, 'public Dictionary<string, System.DateTime> Map1 { get; set; };\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public Dictionary<string, System.DateTime> Map1 { get; set; }').calledOnce.should.be.ok;
         });
     });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Remove ; from the property declaration for a field of type Map.
- Fix the indentation for map properties

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
