### PR TITLE
feat(ts): add flattenSubclassesToUnion param

### DIFF
--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -234,7 +234,6 @@ class TypescriptVisitor {
         if (field.isOptional()) {
             optional = '?';
         }
-
         const isEnumRef = field.isPrimitive() ? false
             : field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName()).isEnum();
 
@@ -249,7 +248,16 @@ class TypescriptVisitor {
             decoratorArguments.length > 0 && (literal = ` = ${field.getType()}.${decoratorArguments}`);
         }
 
-        const tsType = this.toTsType(field.getType(), !isEnumRef && !hasUnion && !isMapRef, hasUnion);
+        let tsType = this.toTsType(field.getType(), !isEnumRef && !hasUnion && !isMapRef, hasUnion);
+
+        // If there exists direct subclasses for this field's declaration then use the union type instead
+        if (!!parameters.flattenSubclassesToUnion & !field.isPrimitive()) {
+            const subclasses = field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName()).getDirectSubclasses();
+            if (subclasses && subclasses.length > 0) {
+                const useUnion = !(isEnumRef || isMapRef);
+                tsType = this.toTsType(field.getType(), !useUnion, useUnion);
+            }
+        }
 
         if (literal) {
             parameters.fileWriter.writeLine(1, field.getName() + literal + ';');

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -624,6 +624,28 @@ describe('TypescriptVisitor', function () {
 
             param.fileWriter.writeLine.withArgs(1, 'literalTest = EnumType.MyEnumValue;').calledOnce.should.be.ok;
         });
+
+        it('should write a line for field name using a union type when the flattenSubclassesToUnion parameter is set', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('flattenSubclassesTest');
+            mockField.getType.returns('Animal');
+            mockField.getDecorators.returns([]);
+
+            const mockModelManager = sinon.createStubInstance(ModelManager);
+            const mockModelFile = sinon.createStubInstance(ModelFile);
+            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.getDirectSubclasses.returns(['blah']); // Not valid, but sufficient for this test
+
+            mockModelManager.getType.returns(mockClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockField.getParent.returns(mockClassDeclaration);
+            typescriptVisitor.visitField(mockField, { ...param, flattenSubclassesToUnion: true });
+
+            param.fileWriter.writeLine.withArgs(1, 'flattenSubclassesTest: AnimalUnion;').calledOnce.should.be.ok;
+        });
     });
 
     describe('visitEnumValueDeclaration', () => {


### PR DESCRIPTION
Some client applications have a preference for union types over inheritance and subclasses (even inside TypeScript).

This change introduces a new parameter that lets the client application control which variant to use when generating TypeScript from Concerto.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds `flattenSubclassesToUnion` parameter to the TypeScriptVisitor. The existing behaviour is still the default

For example, when `flattenSubclassesToUnion = true`, we generate the following code

```typescript
export interface IDecorator extends IConcept {
   name: string;
   arguments?: DecoratorLiteralUnion[];
   location?: IRange;
}
```

instead of the default
```typescript
export interface IDecorator extends IConcept {
   name: string;
   arguments?: IDecoratorLiteral[];
   location?: IRange;
}
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
