### PR TITLE
fix(codegen): prevent vocabulary auto generation for $identifier - I97

### DIFF
--- a/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -179,10 +179,16 @@ class VocabularyVisitor {
     visitProperty(property, parameters) {
         const declarationName = property.getParent().getName();
         const propertyName = property.getName();
+    
+        // Skip generating vocabulary for $identifier
+        if (propertyName === '$identifier') {
+            return null;
+        }
+    
         const propertyVocabulary = VocabularyManager.englishMissingTermGenerator(null, null, declarationName, propertyName);
-
+    
         parameters.fileWriter.writeLine(0, `      - ${propertyName}: ${propertyVocabulary}`);
-
+    
         return null;
     }
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #97 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added condition to return null if the property name equals "$identifier".

### Related Issues
- [Issue #776](https://github.com/accordproject/concerto/issues/776) listed in the concerto repository was the originally reported issue.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:branchname`
