### PR TITLE
fix(codegen): skip vocabulary generation for system property names and add test - I97

### DIFF
--- a/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -16,7 +16,7 @@
 
 const VocabularyManager  = require('@accordproject/concerto-vocabulary').VocabularyManager;
 const util = require('util');
-const ModelUtil = require('../../../../../concerto-core/lib/modelutil.js');
+const { ModelUtil } = require('@accordproject/concerto-core');
 
 /**
  * Convert the contents of a ModelManager to Vocabulary YAML.
@@ -182,7 +182,7 @@ class VocabularyVisitor {
         const propertyName = property.getName();
     
         // Skip generating vocabulary for system property names
-        if (ModelUtil.isSystemProperty(propertyName) == true) {
+        if (ModelUtil.isSystemProperty(propertyName)) {
             return null;
         }
     

--- a/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -16,6 +16,7 @@
 
 const VocabularyManager  = require('@accordproject/concerto-vocabulary').VocabularyManager;
 const util = require('util');
+const ModelUtil = require('../../../../../concerto-core/lib/modelutil.js');
 
 /**
  * Convert the contents of a ModelManager to Vocabulary YAML.
@@ -179,10 +180,16 @@ class VocabularyVisitor {
     visitProperty(property, parameters) {
         const declarationName = property.getParent().getName();
         const propertyName = property.getName();
+    
+        // Skip generating vocabulary for system property names
+        if (ModelUtil.isSystemProperty(propertyName) == true) {
+            return null;
+        }
+    
         const propertyVocabulary = VocabularyManager.englishMissingTermGenerator(null, null, declarationName, propertyName);
-
+    
         parameters.fileWriter.writeLine(0, `      - ${propertyName}: ${propertyVocabulary}`);
-
+    
         return null;
     }
 

--- a/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/lib/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const VocabularyManager  = require('@accordproject/concerto-vocabulary').VocabularyManager;
+const VocabularyManager = require('@accordproject/concerto-vocabulary').VocabularyManager;
 const util = require('util');
 const { ModelUtil } = require('@accordproject/concerto-core');
 
@@ -32,7 +32,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {Object} thing - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @public
      */
@@ -47,7 +47,7 @@ class VocabularyVisitor {
             return this.visitDeclaration(thing, parameters);
         } else if (thing.isMapDeclaration?.()) {
             return this.visitMapDeclaration(thing, parameters);
-        }  else if (thing.isScalarDeclaration?.()) {
+        } else if (thing.isScalarDeclaration?.()) {
             return this.visitScalarDeclaration(thing, parameters);
         } else if (thing.isField?.()) {
             return this.visitProperty(thing, parameters);
@@ -59,8 +59,7 @@ class VocabularyVisitor {
             return this.visitMapKey(thing, parameters);
         } else if (thing.isValue?.()) {
             return this.visitMapValue(thing, parameters);
-        }
-        else {
+        } else {
             throw new Error('Unrecognised type: ' + typeof thing + ', value: ' + util.inspect(thing, {
                 showHidden: true,
                 depth: 2
@@ -71,7 +70,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -85,7 +84,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {ModelFile} modelFile - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -109,7 +108,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {Declaration} declaration - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -118,7 +117,6 @@ class VocabularyVisitor {
         const declarationVocabulary = VocabularyManager.englishMissingTermGenerator(null, null, declarationName);
 
         parameters.fileWriter.writeLine(0, `  - ${declarationName}: ${declarationVocabulary}`);
-
 
         if (declaration.getOwnProperties().length) {
             parameters.fileWriter.writeLine(0, '    properties:');
@@ -133,7 +131,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {ScalarDeclaration} scalarDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -149,7 +147,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {MapDeclaration} mapDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -158,7 +156,6 @@ class VocabularyVisitor {
         const mapDeclarationVocabulary = VocabularyManager.englishMissingTermGenerator(null, null, mapDeclarationName);
 
         parameters.fileWriter.writeLine(0, `  - ${mapDeclarationName}: ${mapDeclarationVocabulary}`);
-
         parameters.fileWriter.writeLine(0, '    properties:');
 
         const mapKey = mapDeclaration.getKey();
@@ -173,30 +170,29 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {Property} property - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
     visitProperty(property, parameters) {
         const declarationName = property.getParent().getName();
         const propertyName = property.getName();
-    
+
         // Skip generating vocabulary for system property names
         if (ModelUtil.isSystemProperty(propertyName)) {
             return null;
         }
-    
+
         const propertyVocabulary = VocabularyManager.englishMissingTermGenerator(null, null, declarationName, propertyName);
-    
         parameters.fileWriter.writeLine(0, `      - ${propertyName}: ${propertyVocabulary}`);
-    
+
         return null;
     }
 
     /**
      * Visitor design pattern
      * @param {MapKeyType} mapKey - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */
@@ -212,7 +208,7 @@ class VocabularyVisitor {
     /**
      * Visitor design pattern
      * @param {MapValueType} mapValue - the object being visited
-     * @param {Object} parameters  - the parameter
+     * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
      * @private
      */

--- a/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -373,6 +373,7 @@ describe('VocabularyVisitor', function () {
                 fileWriter: mockFileWriter
             };
         });
+
         it('should write a line for field name and its vocabulary in english', () => {
             const mockField = sinon.createStubInstance(Field);
             const mockParent = {
@@ -385,6 +386,21 @@ describe('VocabularyVisitor', function () {
             mockField.isPrimitive.returns(true);
             vocabularyVisitor.visitProperty(mockField, param);
             param.fileWriter.writeLine.withArgs(0,'      - name: Name of the Person').calledOnce.should.be.ok;
+        });
+
+        it('should skip vocabulary generation for system property', () => {
+            const mockField = sinon.createStubInstance(Field);
+            const mockParent = {
+                getName: sinon.stub().returns('Person')
+            };
+            mockField.getParent.returns(mockParent);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('$identifier');
+            mockField.isPrimitive.returns(true);
+            const writeLineStub = sinon.stub(mockFileWriter, 'writeLine');
+            vocabularyVisitor.visitProperty(mockField, param);
+            writeLineStub.called.should.be.false;
+            writeLineStub.restore();
         });
     });
 
@@ -464,29 +480,4 @@ describe('VocabularyVisitor', function () {
             param.fileWriter.writeLine.withArgs(0,'      - VALUE: VALUE of the Dictionary').calledOnce.should.be.ok;
         });
     });
-
-    describe('visitProperty for Field', () => {
-        let param;
-        beforeEach(() => {
-            param = {
-                fileWriter: mockFileWriter
-            };
-        });
-        
-        it('should skip vocabulary generation for system property', () => {
-            const mockField = sinon.createStubInstance(Field);
-            const mockParent = {
-                getName: sinon.stub().returns('Person')
-            };
-            mockField.getParent.returns(mockParent);
-            mockField.isPrimitive.returns(false);
-            mockField.getName.returns('$identifier');
-            mockField.isPrimitive.returns(true);
-            const writeLineStub = sinon.stub(mockFileWriter, 'writeLine');
-            vocabularyVisitor.visitProperty(mockField, param);
-            writeLineStub.called.should.be.false;
-            writeLineStub.restore();
-        });
-    });
-    
 });

--- a/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -464,4 +464,29 @@ describe('VocabularyVisitor', function () {
             param.fileWriter.writeLine.withArgs(0,'      - VALUE: VALUE of the Dictionary').calledOnce.should.be.ok;
         });
     });
+
+    describe('visitProperty for Field', () => {
+        let param;
+        beforeEach(() => {
+            param = {
+                fileWriter: mockFileWriter
+            };
+        });
+        
+        it('should skip vocabulary generation for system property', () => {
+            const mockField = sinon.createStubInstance(Field);
+            const mockParent = {
+                getName: sinon.stub().returns('Person')
+            };
+            mockField.getParent.returns(mockParent);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('$identifier');
+            mockField.isPrimitive.returns(true);
+            const writeLineStub = sinon.stub(mockFileWriter, 'writeLine');
+            vocabularyVisitor.visitProperty(mockField, param);
+            writeLineStub.called.should.be.false;
+            writeLineStub.restore();
+        });
+    });
+    
 });

--- a/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
+++ b/test/codegen/fromcto/vocabulary/vocabularyvisitor.js
@@ -367,40 +367,31 @@ describe('VocabularyVisitor', function () {
     });
 
     describe('visitProperty for Field', () => {
-        let param;
-        beforeEach(() => {
-            param = {
-                fileWriter: mockFileWriter
-            };
-        });
-
         it('should write a line for field name and its vocabulary in english', () => {
+            const mockFileWriter = { writeLine: sinon.stub() };
+            const param = { fileWriter: mockFileWriter };
             const mockField = sinon.createStubInstance(Field);
-            const mockParent = {
-                getName: sinon.stub().returns('Person')
-            };
+            const mockParent = { getName: sinon.stub().returns('Person') };
             mockField.getParent.returns(mockParent);
             mockField.isPrimitive.returns(false);
             mockField.getName.returns('name');
             mockField.getType.returns('String');
             mockField.isPrimitive.returns(true);
             vocabularyVisitor.visitProperty(mockField, param);
-            param.fileWriter.writeLine.withArgs(0,'      - name: Name of the Person').calledOnce.should.be.ok;
+            mockFileWriter.writeLine.withArgs(0, '      - name: Name of the Person').calledOnce.should.be.ok;
         });
 
         it('should skip vocabulary generation for system property', () => {
+            const mockFileWriter = { writeLine: sinon.stub() };
+            const param = { fileWriter: mockFileWriter };
             const mockField = sinon.createStubInstance(Field);
-            const mockParent = {
-                getName: sinon.stub().returns('Person')
-            };
+            const mockParent = { getName: sinon.stub().returns('Person') };
             mockField.getParent.returns(mockParent);
             mockField.isPrimitive.returns(false);
             mockField.getName.returns('$identifier');
             mockField.isPrimitive.returns(true);
-            const writeLineStub = sinon.stub(mockFileWriter, 'writeLine');
             vocabularyVisitor.visitProperty(mockField, param);
-            writeLineStub.called.should.be.false;
-            writeLineStub.restore();
+            mockFileWriter.writeLine.called.should.be.false;
         });
     });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #97 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
-  Added condition to return null if propertyName is a reserved system property name.
-  Added unit test to verify that vocabulary is not generated for system property name ("$identifier"). 

### Related Issues
- [This](https://github.com/accordproject/concerto/issues/776) was the originally reported issue (in the [concerto](https://github.com/accordproject/concerto) repository).

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:branchname`
