### PR TITLE
fix: do not crash handling Workday Open API

### DIFF
--- a/lib/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
+++ b/lib/codegen/fromJsonSchema/cto/jsonSchemaVisitor.js
@@ -71,7 +71,7 @@ class JsonSchemaVisitor {
      * @private
      */
     doesObjectContainAlternation(property) {
-        return !!(property.body?.anyOf || property.body?.oneOf);
+        return !!(property.body?.anyOf || property.body?.oneOf || property.body?.allOf);
     }
     /**
      * Process a JSON Schema alternation object containing "anyOf" or a "oneOf"
@@ -86,7 +86,7 @@ class JsonSchemaVisitor {
         // eslint-disable-next-line no-console
         console.warn(
             `Keyword '${
-                alternation.body.anyOf ? 'anyOf' : 'oneOf'
+                alternation.body.anyOf ? 'anyOf' : 'oneOf/allOf'
             }' in definition '${
                 alternation.path[alternation.path.length - 1]
             }' is not fully supported. Defaulting to first alternative.`
@@ -94,7 +94,8 @@ class JsonSchemaVisitor {
 
         return (
             alternation.body.anyOf ||
-            alternation.body.oneOf
+            alternation.body.oneOf ||
+            alternation.body.allOf
         )[0];
     }
     /**
@@ -903,7 +904,7 @@ class JsonSchemaVisitor {
             )
         ) {
             throw new Error(
-                `Type keyword '${nonEnumDefinition.body.type}' in definition '${nameOfDefinition}' is not supported.`
+                `Type keyword '${nonEnumDefinition.body.type}' in definition '${nameOfDefinition}' is not supported. ${JSON.stringify(nonEnumDefinition, null, 2)}`
             );
         }
 

--- a/lib/codegen/fromOpenApi/cto/openApiVisitor.js
+++ b/lib/codegen/fromOpenApi/cto/openApiVisitor.js
@@ -59,6 +59,7 @@ class OpenApiVisitor {
                         .filter(
                             restVerbEntry => requestBodyVerbs
                                 .includes(restVerbEntry[0].toLowerCase()) &&
+                                restVerbEntry[1]?.requestBody?.content &&
                             typeof Object.entries(
                                 restVerbEntry[1].requestBody.content
                             ).find(([k]) => requestBodyContentType.includes(k))

--- a/test/codegen/fromOpenApi/cto/__snapshots__/openApiVisitor.js.snap
+++ b/test/codegen/fromOpenApi/cto/__snapshots__/openApiVisitor.js.snap
@@ -1,0 +1,1949 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OpenApiVisitor should generate a Concerto JSON and CTO from a Workday OpenAPI definition 1`] = `
+{
+  "$class": "concerto.metamodel@1.0.0.Models",
+  "models": [
+    {
+      "$class": "concerto.metamodel@1.0.0.Model",
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "INSTANCE_MODEL_REFERENCE",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": false,
+              "name": "id",
+              "validator": {
+                "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+                "flags": "",
+                "pattern": "^(?:(?:[0-9a-f]{32})|(?:[0-9]+\\$[0-9]+)|(\\S+=\\S+))$",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "href",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "ERROR_MODEL_REFERENCE",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": false,
+              "name": "error",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "code",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "field",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "path",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "VALIDATION_ERROR_MODEL_REFERENCE",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": false,
+              "name": "error",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "errors",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ERROR_MODEL_REFERENCE",
+              },
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "MULTIPLE_INSTANCE_MODEL_REFERENCE",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "total",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "data",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidateSummary_263b3523259410001f3119d56cda126c",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "email",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "phone",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "candidatePhoneDetails_6f9c04282952100023a80fa49bde173d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "name",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "name_59514ca580dc100021a2a27ee1880689",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "prospectSummary_7657284bd7781000178a3bf6e17f001a",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "candidateTags",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "candidateTag_7b4e2f108d3b1000162f47403b7d0037",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "candidatePools",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "candidatePool_7c49be35aa7210001012f723bc6012ca",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "candidate",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "candidateSummary_263b3523259410001f3119d56cda126c",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "contactConsent",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "status",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "type",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "source",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "level",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "referredBy",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "href",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidateEducationDetails_9727f970aa231000052ae7db3fc0000b",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "schoolName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "degree",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "firstYearAttended",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fieldOfStudy",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "lastYearAttended",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "gradeAverage",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "language",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "abilities",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "native",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidateSkillItemDetails_2705750e957f10002beca80792940019",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "name",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "companyName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "location",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "description",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "startYear",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "currentlyWorkHere",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "title",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "startMonth",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "endYear",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "endMonth",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "resumeAttachmentDetailsView_134c3544d220100007f0f9b541a400a5",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fileName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fileExtension",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fileLength",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "jobPostingSiteDetail_8b241418d7ce10000818455b78e40057",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "locationSummary_8b241418d7ce100007a5c9eea7de004c",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "country",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryDetail_8b241418d7ce10000797fe76c17a0046",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "region",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryRegionDetail_8b241418d7ce100007a4d8749d270049",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "organizationDetail_8b241418d7ce100008b027833f33005d",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "name",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "jobPostingAnchorSummary_5597c990f22e10000fc34f022dce0020",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "categories",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "jobSite",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "jobPostingSiteDetail_8b241418d7ce10000818455b78e40057",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "jobDescription",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "primaryLocation",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "locationSummary_8b241418d7ce100007a5c9eea7de004c",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "timeType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "jobType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "spotlightJob",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "additionalLocations",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "locationSummary_8b241418d7ce100007a5c9eea7de004c",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "company",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "organizationDetail_8b241418d7ce100008b027833f33005d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "remoteType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "endDate",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "url",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "startDate",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "title",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "questionnaireDetails_58cd464577ad1000ee76d171eea90000",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "referenceIdValue",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "questionnaireInstructions",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "questions",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "questionItemDetails_35124aec314610000f15a3222d1800f9",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "name",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "questionnaireDisplayName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "href",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "jobRequisitionPublic_df78b8e577c91000162ee14015b600a4",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "primaryRecruiters",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "recruiters",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "hiringManager",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "yearsInCurrentJob",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "totalYearsExperience",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "numberOfJobs",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "interviewEventWithJobApplicationJobRequisitionInterviewerDetails_def69f12d55410000f7ec8da36ae005a",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "interviewStatuses",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "interviewStatusRepresentation_782d6c28615f10000371c7f006740172",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "hasCompetenciesQuestionnaires",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "giveInterviewFeedbackLink",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "jobRequisition",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "jobRequisitionPublic_df78b8e577c91000162ee14015b600a4",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "workersPendingFeedback",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "jobApplication",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "overallRating",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "overallComment",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "interviewers",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "interviewDetailSummary_def69f12d5541000139a7815aae9008f",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "comment",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "overallRating",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "dateSubmitted",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidatePhoneDetails_6f9c04282952100023a80fa49bde173d",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "countryPhoneCode",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "deviceType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "extension",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "phoneNumber",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "name_59514ca580dc100021a2a27ee1880689",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "secondaryLocal",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "firstNameLocal",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "firstNameLocal2",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "social",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "salutation",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fullName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "lastNameLocal2",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "lastName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "secondaryLastName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "middleNameLocal",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "country",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "country_1089da0ab90910000f6d7bd30bb20881",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "firstName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "lastNameLocal",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "middleName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "tertiaryLastName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "hereditary",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "title",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "country_1089da0ab90910000f6d7bd30bb20881",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "questionItemDetails_35124aec314610000f15a3222d1800f9",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "type",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "displayOption",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "body",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "order",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "numberOfSelections",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": true,
+              "isOptional": true,
+              "name": "possibleAnswers",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "required",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "href",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "branchingQuestion",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "questionItemDetails_35124aec314610000f15a3222d1800f9",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "score",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "order",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidateTag_7b4e2f108d3b1000162f47403b7d0037",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "resumeAttachmentDetailsCreate_ee22ee09075410000346b5ebfa2303e4",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+              "isArray": false,
+              "isOptional": false,
+              "name": "fileLength",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "contentType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "fileName",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "countryDetail_8b241418d7ce10000797fe76c17a0046",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "alpha3Code",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "proficiency",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "abilityType",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "INSTANCE_MODEL_REFERENCE",
+              },
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "resumeAttachmentFileView_ee7318fbf39e10001e321c67d42300c0",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "interviewStatusRepresentation_782d6c28615f10000371c7f006740172",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "href",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "countryRegionDetail_8b241418d7ce100007a4d8749d270049",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "code",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "isAbstract": false,
+          "name": "candidatePool_7c49be35aa7210001012f723bc6012ca",
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "id",
+            },
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "isArray": false,
+              "isOptional": true,
+              "name": "descriptor",
+            },
+          ],
+        },
+      ],
+      "decorators": [],
+      "imports": [],
+      "namespace": "com.test@1.0.0",
+    },
+  ],
+}
+`;
+
+exports[`OpenApiVisitor should generate a Concerto JSON and CTO from a Workday OpenAPI definition 2`] = `
+"namespace com.test@1.0.0
+
+concept INSTANCE_MODEL_REFERENCE {
+  o String id regex=/^(?:(?:[0-9a-f]{32})|(?:[0-9]+\\$[0-9]+)|(\\S+=\\S+))$/
+  o String descriptor optional
+  o String href optional
+}
+
+concept ERROR_MODEL_REFERENCE {
+  o String error
+  o String code optional
+  o String field optional
+  o String path optional
+}
+
+concept VALIDATION_ERROR_MODEL_REFERENCE {
+  o String error
+  o ERROR_MODEL_REFERENCE[] errors optional
+}
+
+concept MULTIPLE_INSTANCE_MODEL_REFERENCE {
+  o Integer total optional
+  o INSTANCE_MODEL_REFERENCE[] data optional
+}
+
+concept candidateSummary_263b3523259410001f3119d56cda126c {
+  o String email optional
+  o candidatePhoneDetails_6f9c04282952100023a80fa49bde173d phone optional
+  o name_59514ca580dc100021a2a27ee1880689 name optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept prospectSummary_7657284bd7781000178a3bf6e17f001a {
+  o candidateTag_7b4e2f108d3b1000162f47403b7d0037[] candidateTags optional
+  o candidatePool_7c49be35aa7210001012f723bc6012ca[] candidatePools optional
+  o candidateSummary_263b3523259410001f3119d56cda126c candidate optional
+  o Boolean contactConsent optional
+  o INSTANCE_MODEL_REFERENCE status optional
+  o INSTANCE_MODEL_REFERENCE type optional
+  o INSTANCE_MODEL_REFERENCE source optional
+  o INSTANCE_MODEL_REFERENCE level optional
+  o INSTANCE_MODEL_REFERENCE referredBy optional
+  o String id optional
+  o String descriptor optional
+  o String href optional
+}
+
+concept candidateEducationDetails_9727f970aa231000052ae7db3fc0000b {
+  o String schoolName optional
+  o INSTANCE_MODEL_REFERENCE degree optional
+  o DateTime firstYearAttended optional
+  o INSTANCE_MODEL_REFERENCE fieldOfStudy optional
+  o DateTime lastYearAttended optional
+  o String gradeAverage optional
+  o String id optional
+}
+
+concept candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017 {
+  o INSTANCE_MODEL_REFERENCE language optional
+  o languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022[] abilities optional
+  o Boolean native optional
+  o String id optional
+}
+
+concept candidateSkillItemDetails_2705750e957f10002beca80792940019 {
+  o String name optional
+  o String id optional
+}
+
+concept prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014 {
+  o String companyName optional
+  o String location optional
+  o String description optional
+  o DateTime startYear optional
+  o Boolean currentlyWorkHere optional
+  o String title optional
+  o Integer startMonth optional
+  o DateTime endYear optional
+  o Integer endMonth optional
+  o String id optional
+}
+
+concept resumeAttachmentDetailsView_134c3544d220100007f0f9b541a400a5 {
+  o String fileName optional
+  o String fileExtension optional
+  o Integer fileLength optional
+  o String id optional
+}
+
+concept jobPostingSiteDetail_8b241418d7ce10000818455b78e40057 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept locationSummary_8b241418d7ce100007a5c9eea7de004c {
+  o countryDetail_8b241418d7ce10000797fe76c17a0046 country optional
+  o countryRegionDetail_8b241418d7ce100007a4d8749d270049 region optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a {
+  o String id optional
+  o String descriptor optional
+}
+
+concept organizationDetail_8b241418d7ce100008b027833f33005d {
+  o String id optional
+  o String descriptor optional
+}
+
+concept remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000 {
+  o String name optional
+  o String id optional
+}
+
+concept jobPostingAnchorSummary_5597c990f22e10000fc34f022dce0020 {
+  o jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055[] categories optional
+  o jobPostingSiteDetail_8b241418d7ce10000818455b78e40057 jobSite optional
+  o String jobDescription optional
+  o locationSummary_8b241418d7ce100007a5c9eea7de004c primaryLocation optional
+  o positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053 timeType optional
+  o positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a jobType optional
+  o Boolean spotlightJob optional
+  o locationSummary_8b241418d7ce100007a5c9eea7de004c[] additionalLocations optional
+  o organizationDetail_8b241418d7ce100008b027833f33005d company optional
+  o remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000 remoteType optional
+  o DateTime endDate optional
+  o String url optional
+  o DateTime startDate optional
+  o String title optional
+  o String id optional
+}
+
+concept questionnaireDetails_58cd464577ad1000ee76d171eea90000 {
+  o String referenceIdValue optional
+  o String questionnaireInstructions optional
+  o questionItemDetails_35124aec314610000f15a3222d1800f9[] questions optional
+  o String name optional
+  o String questionnaireDisplayName optional
+  o String id optional
+  o String href optional
+  o String descriptor optional
+}
+
+concept jobRequisitionPublic_df78b8e577c91000162ee14015b600a4 {
+  o workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016[] primaryRecruiters optional
+  o workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016[] recruiters optional
+  o workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016 hiringManager optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7 {
+  o Integer yearsInCurrentJob optional
+  o Integer totalYearsExperience optional
+  o Integer numberOfJobs optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept interviewEventWithJobApplicationJobRequisitionInterviewerDetails_def69f12d55410000f7ec8da36ae005a {
+  o interviewStatusRepresentation_782d6c28615f10000371c7f006740172[] interviewStatuses optional
+  o Boolean hasCompetenciesQuestionnaires optional
+  o String giveInterviewFeedbackLink optional
+  o jobRequisitionPublic_df78b8e577c91000162ee14015b600a4 jobRequisition optional
+  o workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016[] workersPendingFeedback optional
+  o jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7 jobApplication optional
+  o String overallRating optional
+  o String overallComment optional
+  o workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016[] interviewers optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept interviewDetailSummary_def69f12d5541000139a7815aae9008f {
+  o String comment optional
+  o interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092 overallRating optional
+  o DateTime dateSubmitted optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept candidatePhoneDetails_6f9c04282952100023a80fa49bde173d {
+  o INSTANCE_MODEL_REFERENCE countryPhoneCode optional
+  o INSTANCE_MODEL_REFERENCE deviceType optional
+  o String extension optional
+  o String phoneNumber optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept name_59514ca580dc100021a2a27ee1880689 {
+  o String secondaryLocal optional
+  o String firstNameLocal optional
+  o String firstNameLocal2 optional
+  o countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d social optional
+  o countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d salutation optional
+  o String fullName optional
+  o String lastNameLocal2 optional
+  o String lastName optional
+  o String secondaryLastName optional
+  o String middleNameLocal optional
+  o country_1089da0ab90910000f6d7bd30bb20881 country optional
+  o String firstName optional
+  o String lastNameLocal optional
+  o String middleName optional
+  o String tertiaryLastName optional
+  o countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d hereditary optional
+  o countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d title optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept country_1089da0ab90910000f6d7bd30bb20881 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept questionItemDetails_35124aec314610000f15a3222d1800f9 {
+  o INSTANCE_MODEL_REFERENCE type optional
+  o INSTANCE_MODEL_REFERENCE displayOption optional
+  o String body optional
+  o String order optional
+  o Integer numberOfSelections optional
+  o questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104[] possibleAnswers optional
+  o Boolean required optional
+  o String id optional
+  o String href optional
+  o String descriptor optional
+}
+
+concept questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104 {
+  o questionItemDetails_35124aec314610000f15a3222d1800f9 branchingQuestion optional
+  o String id optional
+  o Integer score optional
+  o String descriptor optional
+  o String order optional
+}
+
+concept countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d {
+  o String id optional
+  o String descriptor optional
+}
+
+concept candidateTag_7b4e2f108d3b1000162f47403b7d0037 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept resumeAttachmentDetailsCreate_ee22ee09075410000346b5ebfa2303e4 {
+  o Integer fileLength
+  o INSTANCE_MODEL_REFERENCE contentType optional
+  o String fileName optional
+  o String id optional
+  o String descriptor optional
+}
+
+concept countryDetail_8b241418d7ce10000797fe76c17a0046 {
+  o String alpha3Code optional
+  o String descriptor optional
+}
+
+concept languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022 {
+  o INSTANCE_MODEL_REFERENCE proficiency optional
+  o INSTANCE_MODEL_REFERENCE abilityType optional
+  o String id optional
+}
+
+concept resumeAttachmentFileView_ee7318fbf39e10001e321c67d42300c0 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016 {
+  o String id optional
+  o String descriptor optional
+}
+
+concept interviewStatusRepresentation_782d6c28615f10000371c7f006740172 {
+  o String id optional
+  o String descriptor optional
+  o String href optional
+}
+
+concept countryRegionDetail_8b241418d7ce100007a4d8749d270049 {
+  o String code optional
+  o String descriptor optional
+}
+
+concept candidatePool_7c49be35aa7210001012f723bc6012ca {
+  o String id optional
+  o String descriptor optional
+}"
+`;

--- a/test/codegen/fromOpenApi/cto/data/workday_recruiting_v3.json
+++ b/test/codegen/fromOpenApi/cto/data/workday_recruiting_v3.json
@@ -1,0 +1,4640 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "description": "The Recruiting service enables applications to access Workday data about recruiting, such as job postings, prospects, and interviews.",
+        "version": "v3",
+        "title": "recruiting",
+        "x-workday-internal-source": "xo",
+        "x-workday-internal-routing": "Public",
+        "x-workday-internal-protected-usage-enabled": false,
+        "x-workday-internal-service-container-id": "ba74f44bc90e107329f6353919340036"
+    },
+    "tags": [
+        {
+            "name": "interviews"
+        },
+        {
+            "name": "jobPostings",
+            "description": "Provides the ability to retrieve job postings.",
+            "x-workday-confidence-level": "Production"
+        },
+        {
+            "name": "prospects",
+            "description": "Provides the ability to retrieve and create prospect data."
+        },
+        {
+            "name": "Prompt Values",
+            "description": "Retrieves instances that can be used as values for other endpoint parameters in this service."
+        }
+    ],
+    "paths": {
+        "/prospects/{ID}/experiences/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single experience instance for a \\~prospect\\~.",
+                "description": "Retrieves the work experience with the specified ID for the specified \\~prospect\\~.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/jobPostings/{ID}/questionnaire/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "jobPostings"
+                ],
+                "summary": "Retrieves a single questionnaire for the specified job posting ID.",
+                "description": "Retrieves all questionnaires for the specified job posting ID.\n\nSecured by: Job Postings: External\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/questionnaireDetails_58cd464577ad1000ee76d171eea90000"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-confidence-level": "Production",
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/interviews/{ID}": {
+            "get": {
+                "tags": [
+                    "interviews"
+                ],
+                "description": "Retrieves a collection of interviews.\n\nSecured by: Interview Feedback Public API\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/interviewEventWithJobApplicationJobRequisitionInterviewerDetails_def69f12d55410000f7ec8da36ae005a"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/values/common/countries/": {
+            "get": {
+                "tags": [
+                    "Prompt Values"
+                ],
+                "description": "Retrieves instances that can be used as values for other endpoint parameters in this service.",
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MULTIPLE_INSTANCE_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-protected-usage-enabled": false,
+                "x-workday-internal-try-enabled": "true"
+            },
+            "parameters": [
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "description": "The maximum number of objects in a single response. The default and maximum is 1000.",
+                    "required": false,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                {
+                    "name": "offset",
+                    "in": "query",
+                    "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                    "required": false,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            ]
+        },
+        "/jobPostings": {
+            "get": {
+                "tags": [
+                    "jobPostings"
+                ],
+                "summary": "Retrieves a collection of job postings.",
+                "description": "Retrieves all job postings. You can filter by categories and job sites.\n\nSecured by: Job Postings: External\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "jobPosting",
+                        "in": "query",
+                        "description": "Job Posting for Job Posting Anchor",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "jobRequisition",
+                        "in": "query",
+                        "description": "Job Requisition for Job Posting Anchor",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "jobSite",
+                        "in": "query",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/jobPostingAnchorSummary_5597c990f22e10000fc34f022dce0020"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "true"
+            }
+        },
+        "/prospects": {
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Create \\~prospects\\~.",
+                "description": "Creates a single \\~prospect\\~ instance with the specified data. In the request body, specify at least the required field: candidate.name.country.id. The Recruiting Name Components configuration might require additional fields for candidate.name. To determine additional required fields, see the Recruiting Name Components tab on the Maintain Name Components by \\~Country\\~ task.\n\nSecured by: Create External Prospects, Set Up: External Career Site Access\n\nScope: Recruiting",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/prospectSummary_7657284bd7781000178a3bf6e17f001a"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/prospectSummary_7657284bd7781000178a3bf6e17f001a"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA249 | You must enter the prospect’s email address or phone number.\nA255 | Enter referral as the source when you enter referred by.\nA256 | Enter a name.\nA268 | Enter the referral for the prospect.\nA269 | Enter an email address in this format: xxx@yy.com.\nA274 | Enter a valid format for Phone Number.\nA278 | Enter active candidate pools.\nA284 | Enter active candidate tags.\nA288 | Enter a phone number in the valid format: [PhoneValidationMessage]\nA673 | The Phone Device Type that you specified must be Active.\nA820 | Specify a value for Phone Device Type.\nA821 | You can't specify a Phone Device Type that's Hidden for Recruiting.\nA822 | Specify a value for Phone Number.\nA823 | Specify a value for Country Phone Code.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/languages/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single language instance for a \\~prospect\\~.",
+                "description": "Retrieves the language with the specified ID for the specified \\~prospect\\~.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/educations": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves the education of a single \\~prospect\\~ instance.",
+                "description": "Retrieves the education of the \\~prospect\\~ with the specified ID.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/candidateEducationDetails_9727f970aa231000052ae7db3fc0000b"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA261 | Enter a school name.\nA283 | Enter a last year attended that is after the first year attended.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Creates educations for a \\~prospect\\~.",
+                "description": "To create a single instance, specify the single JSON object in the request body. To create multiple instances, specify \"bulk=true\" as a query parameter. You must specify the JSON object collection in data[ ] in the request body. The maximum collection size is 100.  In the request body, specify at least these required fields: schoolName.\n\nSecured by: Create External Prospects\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/candidateEducationDetails_9727f970aa231000052ae7db3fc0000b"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateEducationDetails_9727f970aa231000052ae7db3fc0000b"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA261 | Enter a school name.\nA283 | Enter a last year attended that is after the first year attended.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/skills/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single skill instance for a \\~prospect\\~.",
+                "description": "Retrieves the skill with the specified ID for the specified \\~prospect\\~.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateSkillItemDetails_2705750e957f10002beca80792940019"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/resumeAttachments/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single resume attachment instance for a \\~prospect\\~.",
+                "description": "Retrieves the resume attachment with the specified ID for the specified \\~prospect\\~.\n\nSecured by: Candidate Data: Attachments\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/resumeAttachmentDetailsView_134c3544d220100007f0f9b541a400a5"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\n\nThe file size should not exceed [file size]MB.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/interviews/{ID}/feedback/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "interviews"
+                ],
+                "description": "Retrieves interview feedback for the specified ID.\n\nSecured by: Interview Feedback Public API\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/interviewDetailSummary_def69f12d5541000139a7815aae9008f"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/jobPostings/{ID}": {
+            "get": {
+                "tags": [
+                    "jobPostings"
+                ],
+                "summary": "Retrieves a job posting.",
+                "description": "Retrieves a job posting with the specified ID\n\nSecured by: Job Postings: External\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/jobPostingAnchorSummary_5597c990f22e10000fc34f022dce0020"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "true"
+            }
+        },
+        "/prospects/{ID}/experiences": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves the work experience of a single \\~prospect\\~ instance.",
+                "description": "Retrieves the work experience of the \\~prospect\\~ with the specified ID.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Creates experiences for a \\~prospect\\~.",
+                "description": "To create a single instance, specify the single JSON object in the request body. To create multiple instances, specify \"bulk=true\" as a query parameter. You must specify the JSON object collection in data[ ] in the request body. The maximum collection size is 100.  In the request body, specify at least these required fields: companyName, title, startYear.\n\nSecured by: Create External Prospects\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA240 | Enter end year when you enter the end month.\nA247 | Enter a title.\nA253 | Enter a number from 1 to 12 for end month.\nA258 | Enter a start year.\nA271 | Enter an end month and end year that occur on or after the start month and start year.\nA282 | Enter a company name.\nA286 | Enter a number from 1 to 12 for start month.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/resumeAttachments/{subresourceID}?type=viewFile": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "description": "Secured by: Candidate Data: Attachments\n\nScope: Recruiting\n\nContains attachment(s)",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/resumeAttachmentFileView_ee7318fbf39e10001e321c67d42300c0"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\n\nThe file size should not exceed [file size]MB.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/resumeAttachments": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves attached resumes for a single \\~prospect\\~ instance.",
+                "description": "Retrieves attached resumes for the \\~prospect\\~ with the specified ID.\n\nSecured by: Candidate Data: Attachments\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/resumeAttachmentDetailsView_134c3544d220100007f0f9b541a400a5"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\n\nThe file size should not exceed [file size]MB.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Creates resume attachments for a \\~prospect\\~.",
+                "description": "Creates a single resume attachment instance with the specified data. In the request body, specify at least these required fields: fileName, attachmentContent.\n\nSecured by: Create External Prospects, Set Up: External Career Site Access\n\nScope: Recruiting\n\nContains attachment(s)",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/resumeAttachmentDetailsCreate_ee22ee09075410000346b5ebfa2303e4"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/resumeAttachmentDetailsCreate_ee22ee09075410000346b5ebfa2303e4"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA246 | One of the following file extensions must be used: [allowed file extensions].\nA252 | Enter a file name.\nA270 | Select a file to upload.\n- | The file size should not exceed [file size]MB.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/interviews/{ID}/feedback": {
+            "get": {
+                "tags": [
+                    "interviews"
+                ],
+                "description": "Retrieves interview feedback for the specified ID.\n\nSecured by: Interview Feedback Public API\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/interviewDetailSummary_def69f12d5541000139a7815aae9008f"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "interviews"
+                ],
+                "description": "Submits interview details for the processing \\~worker\\~ with the interviewer's rating and comment.\n\nSecured by: Interview Feedback Public API\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/interviewDetailSummary_def69f12d5541000139a7815aae9008f"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/interviewDetailSummary_def69f12d5541000139a7815aae9008f"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA129 | You cannot take action on this candidate.\nA130 | Select a valid rating.\nA131 | You cannot submit interview feedback because you are not a part of the interview team.\nA132 | Overall Comment Required (Configure Optional Fields) but not included.  Please contact your administrator.\nA133 | Overall Rating is included but is hidden (Configure Optional Fields).  Please contact your administrator.\nA134 | Overall Comment is included but is hidden (Configure Optional Fields).  Please contact your administrator.\nA135 | Interview feedback task contains competencies, questionnaires, or both; complete feedback using Workday or the Give Interview Feedback URL provided by the API.\nA136 | Overall Rating is Required (Configure Optional Fields) but not included.  Please contact your administrator.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/jobPostings/{ID}/questionnaire": {
+            "get": {
+                "tags": [
+                    "jobPostings"
+                ],
+                "summary": "Retrieves a single questionnaire instance.",
+                "description": "Retrieves a collection of questionnaires.\n\nSecured by: Job Postings: External\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "questionnaireType",
+                        "in": "query",
+                        "description": "questionnaireType",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/questionnaireDetails_58cd464577ad1000ee76d171eea90000"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-confidence-level": "Production",
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/resumeAttachments?type=viewFile": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "description": "Secured by: Candidate Data: Attachments\n\nScope: Recruiting\n\nContains attachment(s)",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/resumeAttachmentFileView_ee7318fbf39e10001e321c67d42300c0"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\n\nThe file size should not exceed [file size]MB.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/educations/{subresourceID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single education instance for a \\~prospect\\~.",
+                "description": "Retrieves the education with specified ID for the specified \\~prospect\\~.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subresourceID",
+                        "in": "path",
+                        "description": "The Workday ID of the subresource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateEducationDetails_9727f970aa231000052ae7db3fc0000b"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA261 | Enter a school name.\nA283 | Enter a last year attended that is after the first year attended.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/languages": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves the languages of a single \\~prospect\\~ instance.",
+                "description": "Retrieves the languages of the \\~prospect\\~ with the specified ID.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Creates languages for a \\~prospect\\~.",
+                "description": "To create a single instance, specify the single JSON object in the request body. To create multiple instances, specify \"bulk=true\" as a query parameter. You must specify the JSON object collection in data[ ] in the request body. The maximum collection size is 100. In the request body, specify at least these required fields: language.id, abilities, abilities.abilityType.\n\nSecured by: Create External Prospects\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA242 | Enter only 1 ability type for the same language.\nA263 | Enter a language.\nA267 | At least one ability for this language is required.\nA290 | Duplicate language entries are not allowed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/interviews": {
+            "get": {
+                "tags": [
+                    "interviews"
+                ],
+                "description": "Retrieves a collection of interviews.\n\nSecured by: Interview Feedback Public API\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "interviewStatus",
+                        "in": "query",
+                        "description": "\"All applicable interview statuses for an Interview event. Statuses can be: \n * AWAITING_ME - An in-progress Interview event is waiting for the logged-in user's feedback. \n * COMPLETED - An Interview event is complete.\n * FEEDBACK_COMPLETE - All interview feedback for this in-progress event was submitted, but the Interview event isn’t awaiting the Make Interview Decision step.\n * NOT_SCHEDULED - An interview hasn't been scheduled for an in-progress Interview event.\n * PENDING_FEEDBACK - An in-progress Interview event is waiting for interviewer feedback.\n * SCHEDULED - An interview is scheduled for an in-progress Interview event.\n * SUBMITTED_FEEDBACK - The logged-in user submitted feedback for an in-progress Interview event.\n * MAKE_INTERVIEW_DECISION - The make an interview decision step for the candidate.\"",
+                        "required": false,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/interviewEventWithJobApplicationJobRequisitionInterviewerDetails_def69f12d55410000f7ec8da36ae005a"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}/skills": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves the skills of a single \\~prospect\\~ instance.",
+                "description": "Retrieves the skills of the \\~prospect\\~ with the specified ID.\n\nSecured by: Prospects\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of objects in a single response. The default is 20. The maximum is 100.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The zero-based index of the first object in a response collection. The default is 0. Use offset with the limit parameter to control paging of a response collection. Example: If limit is 5 and offset is 9, the response returns a collection of 5 objects starting with the 10th object.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/candidateSkillItemDetails_2705750e957f10002beca80792940019"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            },
+            "post": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Creates skills for a \\~prospect\\~.",
+                "description": "To create a single instance, specify the single JSON object in the request body. To create multiple instances, specify \"bulk=true\" as a query parameter. You must specify the JSON object collection in data[ ] in the request body. The maximum collection size is 100. In the request body, specify at least these required fields: name.\n\nSecured by: Create External Prospects\n\nScope: Recruiting",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/candidateSkillItemDetails_2705750e957f10002beca80792940019"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/candidateSkillItemDetails_2705750e957f10002beca80792940019"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)\nError Code | Validation Message\n--- | ---\nA257 | Enter a skill name.\nA259 | You cannot enter duplicate skills.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        },
+        "/prospects/{ID}": {
+            "get": {
+                "tags": [
+                    "prospects"
+                ],
+                "summary": "Retrieves a single \\~prospect\\~ instance.",
+                "description": "Retrieves the \\~prospect\\~ with the specified ID.\n\nSecured by: Prospects, Set Up: External Career Site Access\n\nScope: Recruiting, Talent Pipeline",
+                "parameters": [
+                    {
+                        "name": "ID",
+                        "in": "path",
+                        "description": "The Workday ID of the resource.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response. A successful response can return no matched data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/prospectSummary_7657284bd7781000178a3bf6e17f001a"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid resource or operation. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "User has insufficient permissions. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found. (https://community.workday.com/rest/error-messages)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VALIDATION_ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-workday-internal-try-enabled": "false"
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "https://<tenantHostname>/recruiting/v3"
+        }
+    ],
+    "components": {
+        "securitySchemes": {
+            "OAuth2": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://<tenantAuthorizationHostname>",
+                        "scopes": {}
+                    }
+                }
+            }
+        },
+        "schemas": {
+            "INSTANCE_MODEL_REFERENCE": {
+                "type": "object",
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "wid / id / reference id",
+                        "pattern": "^(?:(?:[0-9a-f]{32})|(?:[0-9]+\\$[0-9]+)|(\\S+=\\S+))$"
+                    },
+                    "descriptor": {
+                        "type": "string",
+                        "description": "A description of the instance",
+                        "readOnly": true
+                    },
+                    "href": {
+                        "type": "string",
+                        "description": "A link to the instance",
+                        "readOnly": true
+                    }
+                }
+            },
+            "ERROR_MODEL_REFERENCE": {
+                "type": "object",
+                "required": [
+                    "error"
+                ],
+                "properties": {
+                    "error": {
+                        "type": "string",
+                        "description": "A description of the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The code that corresponds to the error message. Use the error code to drive programmatic error-handling behavior. Don't use error message strings for this purpose because they are subject to change"
+                    },
+                    "field": {
+                        "type": "string",
+                        "description": "The field related to the error"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "The path of the field related to the error"
+                    }
+                }
+            },
+            "VALIDATION_ERROR_MODEL_REFERENCE": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "error"
+                        ],
+                        "properties": {
+                            "error": {
+                                "type": "string",
+                                "description": "A description of the error"
+                            },
+                            "errors": {
+                                "type": "array",
+                                "description": "An array of validation errors",
+                                "items": {
+                                    "$ref": "#/components/schemas/ERROR_MODEL_REFERENCE"
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "FACETS_MODEL_REFERENCE": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "description": "This object represents the possible facets for this resource",
+                    "readOnly": true,
+                    "properties": {
+                        "descriptor": {
+                            "type": "string",
+                            "description": "A description of the facet"
+                        },
+                        "facetParameter": {
+                            "type": "string",
+                            "description": "The alias used to select the facet"
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "the facet values",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "count": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "description": "The number of instances returned by this facet"
+                                    },
+                                    "id": {
+                                        "type": "string",
+                                        "description": "wid / id / reference id",
+                                        "pattern": "^(?:(?:[0-9a-f]{32})|(?:[0-9]+\\$[0-9]+)|(\\S+=\\S+))$"
+                                    },
+                                    "descriptor": {
+                                        "type": "string",
+                                        "description": "A description of the facet"
+                                    },
+                                    "href": {
+                                        "type": "string",
+                                        "description": "A link to the instance",
+                                        "readOnly": true
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "MULTIPLE_INSTANCE_MODEL_REFERENCE": {
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                        }
+                    }
+                }
+            },
+            "candidate_263b3523259410001ed40f0f6518126a": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/candidateSummary_263b3523259410001f3119d56cda126c"
+                    },
+                    {}
+                ],
+                "description": "The candidate profile associated with this \\~Prospect\\~."
+            },
+            "status_4e798b9f4f0c10000f0d81a848650021": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Returns the \\~Prospect\\~ Status for this \\~Prospect\\~."
+            },
+            "type_4e798b9f4f0c10000f0d819e58340020": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The type for the \\~Prospect\\~."
+            },
+            "source_4e798b9f4f0c10000f0d818b76f6001f": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The source for the \\~Prospect\\~ (linkedin, facebook, etc)."
+            },
+            "level_4e798b9f4f0c10000f0d81b1a0740022": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The targeted management level for the \\~Prospect\\~."
+            },
+            "referredBy_4e798b9f4f0c10000f0d81ba535a0023": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The \\~worker\\~ who referred the job application."
+            },
+            "prospectSummary_7657284bd7781000178a3bf6e17f001a": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "candidateTags": {
+                                "type": "array",
+                                "description": "The candidate tags associated with the candidate.",
+                                "items": {
+                                    "$ref": "#/components/schemas/candidateTag_7b4e2f108d3b1000162f47403b7d0037"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "candidatePools": {
+                                "type": "array",
+                                "description": "The active, static pools for the candidate.",
+                                "items": {
+                                    "$ref": "#/components/schemas/candidatePool_7c49be35aa7210001012f723bc6012ca"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "candidate": {
+                                "$ref": "#/components/schemas/candidate_263b3523259410001ed40f0f6518126a"
+                            },
+                            "contactConsent": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "If true, the candidate agrees to be contacted.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "status": {
+                                "$ref": "#/components/schemas/status_4e798b9f4f0c10000f0d81a848650021"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/type_4e798b9f4f0c10000f0d819e58340020"
+                            },
+                            "source": {
+                                "$ref": "#/components/schemas/source_4e798b9f4f0c10000f0d818b76f6001f"
+                            },
+                            "level": {
+                                "$ref": "#/components/schemas/level_4e798b9f4f0c10000f0d81b1a0740022"
+                            },
+                            "referredBy": {
+                                "$ref": "#/components/schemas/referredBy_4e798b9f4f0c10000f0d81ba535a0023"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            },
+                            "href": {
+                                "type": "string",
+                                "description": "A link to the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "degree_9727f970aa23100005e6ec6727ee0011": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The degree for a candidate's job application at the associated educational institution."
+            },
+            "fieldOfStudy_9727f970aa23100005e6ec5e7dd10010": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The field of study for the associated candidate at this educational institution."
+            },
+            "candidateEducationDetails_9727f970aa231000052ae7db3fc0000b": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "schoolName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The name of the school the candidate attended or is attending.",
+                                "x-workday-type": "Text"
+                            },
+                            "degree": {
+                                "$ref": "#/components/schemas/degree_9727f970aa23100005e6ec6727ee0011"
+                            },
+                            "firstYearAttended": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The first year the candidate attended this educational institution.",
+                                "x-workday-type": "Date"
+                            },
+                            "fieldOfStudy": {
+                                "$ref": "#/components/schemas/fieldOfStudy_9727f970aa23100005e6ec5e7dd10010"
+                            },
+                            "lastYearAttended": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The last year the candidate attended this educational institution.",
+                                "x-workday-type": "Date"
+                            },
+                            "gradeAverage": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The candidate's grade average at this educational institution.",
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "language_ecf7ccfb11c11000285d4771a6300019": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Returns the language for this Language Skill."
+            },
+            "candidateLanguageSkillDetails_ecf7ccfb11c11000285d4727e4270017": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "language": {
+                                "$ref": "#/components/schemas/language_ecf7ccfb11c11000285d4771a6300019"
+                            },
+                            "abilities": {
+                                "type": "array",
+                                "description": "The abilities associated with this language skill.",
+                                "items": {
+                                    "$ref": "#/components/schemas/languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "native": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "If true, this language skill is the native language.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "candidateSkillItemDetails_2705750e957f10002beca80792940019": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The name of the candidate skill.",
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "prospectExperienceDetails_b4dba3cbddc710001bebf80c43270014": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "companyName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The company name the candidate entered in their job history.",
+                                "x-workday-type": "Text"
+                            },
+                            "location": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The location of this company.",
+                                "x-workday-type": "Text"
+                            },
+                            "description": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "Any responsibilities or accomplishments that the candidate gained at the associated company.",
+                                "x-workday-type": "Text"
+                            },
+                            "startYear": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The year the candidate started employment at this company.",
+                                "x-workday-type": "Date"
+                            },
+                            "currentlyWorkHere": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "If true, the candidate currently works at this company.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "title": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The business title for the candidate's work experience.",
+                                "x-workday-type": "Text"
+                            },
+                            "startMonth": {
+                                "type": "integer",
+                                "example": "95",
+                                "description": "The month the candidate started employment at this company.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "endYear": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The year the candidate ended employment at this company.",
+                                "x-workday-type": "Date"
+                            },
+                            "endMonth": {
+                                "type": "integer",
+                                "example": "25",
+                                "description": "The month the candidate ended employment at this company.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "resumeAttachmentDetailsView_134c3544d220100007f0f9b541a400a5": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "fileName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The file name of the attachment.",
+                                "maxLength": 255,
+                                "x-workday-type": "Text"
+                            },
+                            "fileExtension": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The file extension of the attachment.",
+                                "x-workday-type": "Text"
+                            },
+                            "fileLength": {
+                                "type": "integer",
+                                "example": "1892173442",
+                                "description": "The file length of the attachment.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobSite_8b241418d7ce1000073b5115cd300040": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/jobPostingSiteDetail_8b241418d7ce10000818455b78e40057"
+                    },
+                    {}
+                ],
+                "description": "The job posting site that the job is posted on."
+            },
+            "primaryLocation_8b241418d7ce1000073b51293ed40043": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/locationSummary_8b241418d7ce100007a5c9eea7de004c"
+                    },
+                    {}
+                ],
+                "description": "The primary location for the job posting, according to the associated job requisition."
+            },
+            "timeType_8b241418d7ce1000073b510155b0003d": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053"
+                    },
+                    {}
+                ],
+                "description": "The position time type for job posting."
+            },
+            "jobType_8b241418d7ce1000073b511c6e2a0041": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a"
+                    },
+                    {}
+                ],
+                "description": "The \\~worker\\~ sub-type for the job posting, according to the job requisition."
+            },
+            "company_8b241418d7ce1000073b5122b5a90042": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/organizationDetail_8b241418d7ce100008b027833f33005d"
+                    },
+                    {}
+                ],
+                "description": "The \\~supervisory organization\\~ assigned to the job requisition associated with the job posting."
+            },
+            "remoteType_d0be7f99be971000125025ffa1c40000": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000"
+                    },
+                    {}
+                ],
+                "description": "The Job Requisition Remote Type for a Job Posting. For Remote Types with an External Name, the given external name is returned."
+            },
+            "jobPostingAnchorSummary_5597c990f22e10000fc34f022dce0020": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "categories": {
+                                "type": "array",
+                                "description": "The job family group for the job posting, according to the job requisition.",
+                                "items": {
+                                    "$ref": "#/components/schemas/jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "jobSite": {
+                                "$ref": "#/components/schemas/jobSite_8b241418d7ce1000073b5115cd300040"
+                            },
+                            "jobDescription": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The description of the job for the job posting.",
+                                "x-workday-type": "Rich Text"
+                            },
+                            "primaryLocation": {
+                                "$ref": "#/components/schemas/primaryLocation_8b241418d7ce1000073b51293ed40043"
+                            },
+                            "timeType": {
+                                "$ref": "#/components/schemas/timeType_8b241418d7ce1000073b510155b0003d"
+                            },
+                            "jobType": {
+                                "$ref": "#/components/schemas/jobType_8b241418d7ce1000073b511c6e2a0041"
+                            },
+                            "spotlightJob": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "True if the job posting is a \\~Spotlight Job\\~ or not.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "additionalLocations": {
+                                "type": "array",
+                                "description": "The additional locations on the job posting, according to the job requisition.",
+                                "items": {
+                                    "$ref": "#/components/schemas/locationSummary_8b241418d7ce100007a5c9eea7de004c"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "company": {
+                                "$ref": "#/components/schemas/company_8b241418d7ce1000073b5122b5a90042"
+                            },
+                            "remoteType": {
+                                "$ref": "#/components/schemas/remoteType_d0be7f99be971000125025ffa1c40000"
+                            },
+                            "endDate": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The end date for the job posting.",
+                                "x-workday-type": "Date"
+                            },
+                            "url": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "External URL for Job Posting if it is posted to a published Workday External Career Site.",
+                                "x-workday-type": "Text"
+                            },
+                            "startDate": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The start date for the job posting.",
+                                "x-workday-type": "Date"
+                            },
+                            "title": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The title of the job posting, according to the associated job requisition.",
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "questionnaireDetails_58cd464577ad1000ee76d171eea90000": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "referenceIdValue": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The reference ID for the Questionnaire",
+                                "x-workday-type": "Text"
+                            },
+                            "questionnaireInstructions": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "Returns instructions for the questionnaire. These instructions may be overridden where the questionnaire is being used.",
+                                "x-workday-type": "Rich Text"
+                            },
+                            "questions": {
+                                "type": "array",
+                                "description": "Returns all Parent-Level Question Items for the questionnaire",
+                                "items": {
+                                    "$ref": "#/components/schemas/questionItemDetails_35124aec314610000f15a3222d1800f9"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The name of the questionnaire.",
+                                "x-workday-type": "Text"
+                            },
+                            "questionnaireDisplayName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The display name for the questionnaire.",
+                                "x-workday-type": "Text",
+                                "x-workday-confidence-level": "Production"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "href": {
+                                "type": "string",
+                                "description": "A link to the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobRequisition_df78b8e577c9100015f051a74e0b00a2": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/jobRequisitionPublic_df78b8e577c91000162ee14015b600a4"
+                    },
+                    {}
+                ],
+                "description": "The Job Requisition applied to by the associated candidate. Only return if user has access to the recruiting event through \"Candidate Data:Interview Feedback Results\" domain, or user is an interviewer for the in progress interview event."
+            },
+            "jobApplication_df78b8e577c91000201ea3e7d0f60101": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7"
+                    },
+                    {}
+                ],
+                "description": "The Job Application for the recruiting event. Only return if user has access to it either through \"Candidate Data:Interview Feedback Results\" domain, or user is an interviewer for the in progress interview event."
+            },
+            "interviewEventWithJobApplicationJobRequisitionInterviewerDetails_def69f12d55410000f7ec8da36ae005a": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "interviewStatuses": {
+                                "type": "array",
+                                "description": "\"All applicable interview statuses for an Interview event. Statuses can be: \n * AWAITING_ME - An in-progress Interview event is waiting for the logged-in user's feedback. \n * COMPLETED - An Interview event is complete.\n * FEEDBACK_COMPLETE - All interview feedback for this in-progress event was submitted, but the Interview event isn’t awaiting the Make Interview Decision step.\n * NOT_SCHEDULED - An interview hasn't been scheduled for an in-progress Interview event.\n * PENDING_FEEDBACK - An in-progress Interview event is waiting for interviewer feedback.\n * SCHEDULED - An interview is scheduled for an in-progress Interview event.\n * SUBMITTED_FEEDBACK - The logged-in user submitted feedback for an in-progress Interview event.\n * MAKE_INTERVIEW_DECISION - The make an interview decision step for the candidate.\"",
+                                "items": {
+                                    "$ref": "#/components/schemas/interviewStatusRepresentation_782d6c28615f10000371c7f006740172"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "hasCompetenciesQuestionnaires": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "If true, the interviewer feedback task awaiting processing has Competencies or Questionnaires with configured XIP settings.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "giveInterviewFeedbackLink": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "A URL for the Give Interview Feedback task, for \\~workers\\~ with access to the Interview Feedback Detail event awaiting processing.",
+                                "x-workday-type": "Text"
+                            },
+                            "jobRequisition": {
+                                "$ref": "#/components/schemas/jobRequisition_df78b8e577c9100015f051a74e0b00a2"
+                            },
+                            "workersPendingFeedback": {
+                                "type": "array",
+                                "description": "Interviewers with pending interview feedback.",
+                                "items": {
+                                    "$ref": "#/components/schemas/workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "jobApplication": {
+                                "$ref": "#/components/schemas/jobApplication_df78b8e577c91000201ea3e7d0f60101"
+                            },
+                            "overallRating": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The Overall Rating XIP configuration formatted as text.",
+                                "x-workday-type": "Text"
+                            },
+                            "overallComment": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The Overall Comment XIP configuration formatted as text.",
+                                "x-workday-type": "Text"
+                            },
+                            "interviewers": {
+                                "type": "array",
+                                "description": "All  \\~workers\\~ selected to interview the candidate for a given Interview event.",
+                                "items": {
+                                    "$ref": "#/components/schemas/workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "overallRating_def69f12d5541000141441c84bd00096": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092"
+                    },
+                    {}
+                ],
+                "description": "The rating left by the interviewer."
+            },
+            "interviewDetailSummary_def69f12d5541000139a7815aae9008f": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "comment": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The interviewer's overall and competency comments.",
+                                "x-workday-type": "Text"
+                            },
+                            "overallRating": {
+                                "$ref": "#/components/schemas/overallRating_def69f12d5541000141441c84bd00096"
+                            },
+                            "dateSubmitted": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2024-05-04T07:00:00.000Z",
+                                "description": "The feedback submission date.",
+                                "x-workday-type": "Date"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "countryPhoneCode_6f9c04282952100023a80fd30a5f173e": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Phone \\~country\\~"
+            },
+            "deviceType_6f9c0428295210002484a8f3720f1796": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The type of phone number."
+            },
+            "candidatePhoneDetails_6f9c04282952100023a80fa49bde173d": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "countryPhoneCode": {
+                                "$ref": "#/components/schemas/countryPhoneCode_6f9c04282952100023a80fd30a5f173e"
+                            },
+                            "deviceType": {
+                                "$ref": "#/components/schemas/deviceType_6f9c0428295210002484a8f3720f1796"
+                            },
+                            "extension": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The phone number extension.",
+                                "x-workday-type": "Text"
+                            },
+                            "phoneNumber": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The full primary phone number of the person.",
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "phone_4d9dacbbb7bb10000c97867b421a4c7e": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/candidatePhoneDetails_6f9c04282952100023a80fa49bde173d"
+                    },
+                    {}
+                ],
+                "description": "The candidate's primary home phone number."
+            },
+            "name_59514ca580dc100021a481f97c54068b": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/name_59514ca580dc100021a2a27ee1880689"
+                    },
+                    {}
+                ],
+                "description": "The global name associated with the candidate."
+            },
+            "candidateSummary_263b3523259410001f3119d56cda126c": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "email": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The candidate's email address.",
+                                "x-workday-type": "Text"
+                            },
+                            "phone": {
+                                "$ref": "#/components/schemas/phone_4d9dacbbb7bb10000c97867b421a4c7e"
+                            },
+                            "name": {
+                                "$ref": "#/components/schemas/name_59514ca580dc100021a481f97c54068b"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "country_1089da0ab90910000f6d7bd30bb20881": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobFamilyGroupDetail_8b241418d7ce1000081068ca51810055": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "branchingQuestion_b846d79e92ac100013f9842aa5700161": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/questionItemDetails_35124aec314610000f15a3222d1800f9"
+                    },
+                    {}
+                ],
+                "description": "Branching Question Item for Question Score"
+            },
+            "questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "branchingQuestion": {
+                                "$ref": "#/components/schemas/branchingQuestion_b846d79e92ac100013f9842aa5700161"
+                            },
+                            "id": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The Workday ID for the Question Multiple Choice Answer",
+                                "x-workday-type": "Text"
+                            },
+                            "score": {
+                                "type": "integer",
+                                "example": "1186713525",
+                                "description": "Returns the score for the multiple choice answer configured for the multiple choice question.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The answer text for the Question Multiple Choice Answer",
+                                "x-workday-type": "Text"
+                            },
+                            "order": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The order for the Question Multiple Choice Answer",
+                                "x-workday-type": "Text"
+                            }
+                        }
+                    }
+                ]
+            },
+            "countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "candidateTag_7b4e2f108d3b1000162f47403b7d0037": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "contentType_ee22ee09075410000346b6722d9b03e8": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Content type of the attachment"
+            },
+            "resumeAttachmentDetailsCreate_ee22ee09075410000346b5ebfa2303e4": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "fileLength"
+                        ],
+                        "properties": {
+                            "fileLength": {
+                                "type": "integer",
+                                "example": "828115526",
+                                "description": "The file length of the attachment.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "contentType": {
+                                "$ref": "#/components/schemas/contentType_ee22ee09075410000346b6722d9b03e8"
+                            },
+                            "fileName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The file name of the attachment.",
+                                "maxLength": 255,
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "organizationDetail_8b241418d7ce100008b027833f33005d": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "countryDetail_8b241418d7ce10000797fe76c17a0046": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "alpha3Code": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The ISO alpha-3 code for a country.",
+                                "maxLength": 3,
+                                "x-workday-type": "Text"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "proficiency_ecf7ccfb11c110002a0cd3c79f4c0023": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Returns the proficiency for a specific ability of a language."
+            },
+            "abilityType_ecf7ccfb11c110002a0cd3d48d1d0024": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Returns the language ability type."
+            },
+            "languageAbilityDetails_ecf7ccfb11c110002a0cd3b3ff8b0022": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "proficiency": {
+                                "$ref": "#/components/schemas/proficiency_ecf7ccfb11c110002a0cd3c79f4c0023"
+                            },
+                            "abilityType": {
+                                "$ref": "#/components/schemas/abilityType_ecf7ccfb11c110002a0cd3d48d1d0024"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "positionTimeTypeDetail_8b241418d7ce100007fe51d00f630053": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "interviewFeedbackRatingSummary_def69f12d554100013fe5747ffa50092": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "resumeAttachmentFileView_ee7318fbf39e10001e321c67d42300c0": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobApplicationPublic_b36c621f46fd10001cc501100a4e03c7": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "yearsInCurrentJob": {
+                                "type": "integer",
+                                "example": "664956081",
+                                "description": "The number of years the candidate has been employed at their current job",
+                                "x-workday-type": "Numeric"
+                            },
+                            "totalYearsExperience": {
+                                "type": "integer",
+                                "example": "1156131973",
+                                "description": "The total years of experience for the candidate on this job application.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "numberOfJobs": {
+                                "type": "integer",
+                                "example": "636732",
+                                "description": "The number of jobs for a candidate on this job application.",
+                                "x-workday-type": "Numeric"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "remoteTypeDefinition_8bdd07e7084f1000151e15ccc3dd0000": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The external or internal name of the Job Requisition Remote Type for the given Job Posting.",
+                                "x-workday-type": "Text"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "interviewStatusRepresentation_782d6c28615f10000371c7f006740172": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            },
+                            "href": {
+                                "type": "string",
+                                "description": "A link to the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "countryRegionDetail_8b241418d7ce100007a4d8749d270049": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The region-only portion of the ISO 3166-2 code for a country region.",
+                                "x-workday-type": "Text"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobPostingSiteDetail_8b241418d7ce10000818455b78e40057": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "hiringManager_b47f16fb63e910000a6ac5854fd4021c": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016"
+                    },
+                    {}
+                ],
+                "description": "Hiring Manager for a Job Requisition."
+            },
+            "jobRequisitionPublic_df78b8e577c91000162ee14015b600a4": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "primaryRecruiters": {
+                                "type": "array",
+                                "description": "The primary recruiters assigned to the job requisition. If no primary recruiter is assigned, the field is blank.",
+                                "items": {
+                                    "$ref": "#/components/schemas/workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "recruiters": {
+                                "type": "array",
+                                "description": "The non-primary recruiters assigned to the job requisition.",
+                                "items": {
+                                    "$ref": "#/components/schemas/workerForInterviewRepresentation_0e1101ea4ec4100008fdfd8289ed0016"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "hiringManager": {
+                                "$ref": "#/components/schemas/hiringManager_b47f16fb63e910000a6ac5854fd4021c"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "type_35124aec314610000f15a34518bf00ff": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "The type of the question."
+            },
+            "displayOption_35124aec314610000f15a32daa6600fa": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/INSTANCE_MODEL_REFERENCE"
+                    },
+                    {}
+                ],
+                "description": "Returns the display option selected for the question. Answer choices will be presented this way to users answering the question."
+            },
+            "questionItemDetails_35124aec314610000f15a3222d1800f9": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "$ref": "#/components/schemas/type_35124aec314610000f15a34518bf00ff"
+                            },
+                            "displayOption": {
+                                "$ref": "#/components/schemas/displayOption_35124aec314610000f15a32daa6600fa"
+                            },
+                            "body": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The body of the question.",
+                                "x-workday-type": "Text"
+                            },
+                            "order": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The order of the question within the questionnaire.",
+                                "x-workday-type": "Text"
+                            },
+                            "numberOfSelections": {
+                                "type": "integer",
+                                "example": "46",
+                                "description": "The number of allowed answers for a question for a questionnaire",
+                                "x-workday-type": "Numeric"
+                            },
+                            "possibleAnswers": {
+                                "type": "array",
+                                "description": "Returns the scores for the multiple choice answers configured for the multiple choice question.",
+                                "items": {
+                                    "$ref": "#/components/schemas/questionMultipleChoiceAnswerDetails_35124aec314610000f355986c6490104"
+                                },
+                                "x-workday-type": "Multi-instance"
+                            },
+                            "required": {
+                                "type": "boolean",
+                                "example": true,
+                                "description": "Indicator whether the answer for the question is required.",
+                                "x-workday-type": "Boolean"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "href": {
+                                "type": "string",
+                                "description": "A link to the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "candidatePool_7c49be35aa7210001012f723bc6012ca": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "social_a229cf3cded91000151b47c7e0e2012c": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d"
+                    },
+                    {}
+                ],
+                "description": "Returns the social suffix from the name."
+            },
+            "salutation_a229cf3cded91000151b47b82570012a": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d"
+                    },
+                    {}
+                ],
+                "description": "Returns the salutation from the name."
+            },
+            "country_a229cf3cded91000151b47775e040123": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/country_1089da0ab90910000f6d7bd30bb20881"
+                    },
+                    {}
+                ],
+                "description": "Returns the \\~country\\~ from the name."
+            },
+            "hereditary_a229cf3cded91000151b479726220126": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d"
+                    },
+                    {}
+                ],
+                "description": "Returns the hereditary suffix from the name."
+            },
+            "title_a229cf3cded91000151b47af4c400129": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryPredefinedNameComponent_e16f06ca954910001a110a8851cd013d"
+                    },
+                    {}
+                ],
+                "description": "Returns the prefix from the name."
+            },
+            "name_59514ca580dc100021a2a27ee1880689": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "secondaryLocal": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's secondary family name in local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "firstNameLocal": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's given name in local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "firstNameLocal2": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's given name in second local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "social": {
+                                "$ref": "#/components/schemas/social_a229cf3cded91000151b47c7e0e2012c"
+                            },
+                            "salutation": {
+                                "$ref": "#/components/schemas/salutation_a229cf3cded91000151b47b82570012a"
+                            },
+                            "fullName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The Full Name for a person, when it is provided. Workday only tracks Full Name for countries where the Full Name name component is used.",
+                                "x-workday-type": "Text"
+                            },
+                            "lastNameLocal2": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's last name in second local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "lastName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's family name.",
+                                "x-workday-type": "Text"
+                            },
+                            "secondaryLastName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The secondary family name for a person.",
+                                "x-workday-type": "Text"
+                            },
+                            "middleNameLocal": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's middle name in local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "country": {
+                                "$ref": "#/components/schemas/country_a229cf3cded91000151b47775e040123"
+                            },
+                            "firstName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The first or given name for a person.",
+                                "x-workday-type": "Text"
+                            },
+                            "lastNameLocal": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's last name in local script.  Workday only tracks local names for countries where a non-Latin script is commonly used.",
+                                "x-workday-type": "Text"
+                            },
+                            "middleName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's middle name.",
+                                "x-workday-type": "Text"
+                            },
+                            "tertiaryLastName": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit amet, cum choro singulis consectetuer ut, ubique iisque contentiones ex duo. Quo lorem etiam eu.",
+                                "description": "The person's tertiary last name.",
+                                "x-workday-type": "Text"
+                            },
+                            "hereditary": {
+                                "$ref": "#/components/schemas/hereditary_a229cf3cded91000151b479726220126"
+                            },
+                            "title": {
+                                "$ref": "#/components/schemas/title_a229cf3cded91000151b47af4c400129"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "positionWorkerTypeDetail_8b241418d7ce1000089e70503c92005a": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            },
+            "country_8b241418d7ce100007a5ca00337b004d": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryDetail_8b241418d7ce10000797fe76c17a0046"
+                    },
+                    {}
+                ],
+                "description": "Returns the \\~country\\~ from the primary address for the location."
+            },
+            "region_8b241418d7ce100007a5ca0b072e004e": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/countryRegionDetail_8b241418d7ce100007a4d8749d270049"
+                    },
+                    {}
+                ],
+                "description": "Returns the country region for the location."
+            },
+            "locationSummary_8b241418d7ce100007a5c9eea7de004c": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "country": {
+                                "$ref": "#/components/schemas/country_8b241418d7ce100007a5ca00337b004d"
+                            },
+                            "region": {
+                                "$ref": "#/components/schemas/region_8b241418d7ce100007a5ca0b072e004e"
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Id of the instance"
+                            },
+                            "descriptor": {
+                                "type": "string",
+                                "example": "Lorem ipsum dolor sit ame",
+                                "description": "A preview of the instance"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/codegen/fromOpenApi/cto/openApiVisitor.js
+++ b/test/codegen/fromOpenApi/cto/openApiVisitor.js
@@ -17,6 +17,8 @@
 const chai = require('chai');
 chai.should();
 const { assert } = chai;
+const { expect } = require('expect');
+
 const fs = require('fs');
 const path = require('path');
 const Printer = require('@accordproject/concerto-cto').Printer;
@@ -161,6 +163,31 @@ describe('OpenApiVisitor', function () {
                 inferredConcertoModel,
                 desiredConcertoModel
             );
+        }
+    );
+
+    it(
+        'should generate a Concerto JSON and CTO from a Workday OpenAPI definition',
+        async () => {
+            const openApiDefinition = JSON.parse(
+                fs.readFileSync(
+                    path.resolve(
+                        __dirname, '../cto/data/workday_recruiting_v3.json'
+                    ), 'utf8'
+                )
+            );
+            const inferredConcertoJsonModel = OpenApiVisitor
+                .parse(openApiDefinition)
+                .accept(
+                    openApiVisitor, openApiVisitorParameters
+                );
+
+            expect(inferredConcertoJsonModel).toMatchSnapshot();
+
+            const inferredConcertoModel = Printer.toCTO(
+                inferredConcertoJsonModel.models[0]
+            );
+            expect(inferredConcertoModel).toMatchSnapshot();
         }
     );
 });


### PR DESCRIPTION
Fix a crash in inferring a model from the Workday Open API.

### Changes
- Do not crash on a JSON schema that contains an `allOf` 

### Flags
- Just uses the first child of the `allOf` (same logic as we have for `anyOf` and `oneOf`
 
### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
