### PR TITLE
feat(dependency graph): add option to create a dependency graph

### DIFF
--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -185,7 +185,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
         if (classDeclaration.getSuperType()){
             parameters.graph.addEdge(classDeclaration.getFullyQualifiedName(), classDeclaration.getSuperType());
             // this "if" block adds the types that extend the Super type
-            if(classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
+            if(!parameters.createDependencyGraph && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
                 parameters.graph.addVertex(classDeclaration.getSuperType());
                 parameters.graph.addEdge(classDeclaration.getSuperType(), classDeclaration.getFullyQualifiedName());
             }

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -246,7 +246,7 @@ describe('graph', function() {
 `);
         });
 
-        it('should visit a model manager and create a dependencyGraph', function() {
+        it('should visit a model manager and create a dependency graph', function() {
             const visitor = new ConcertoGraphVisitor();
             visitor.should.not.be.null;
             const writer = new InMemoryWriter();

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -15,7 +15,10 @@
 
 'use strict';
 
-const { DirectedGraph, ConcertoGraphVisitor } = require('../../lib/common/common.js');
+const {
+    DirectedGraph,
+    ConcertoGraphVisitor,
+} = require('../../lib/common/common.js');
 const { ModelManager } = require('@accordproject/concerto-core');
 const fs = require('fs');
 const { expect } = require('expect');
@@ -26,7 +29,7 @@ chai.should();
 chai.use(require('chai-as-promised'));
 chai.use(require('chai-things'));
 
-describe('graph', function () {
+describe('graph', function() {
     let modelManager = null;
 
     before(function() {
@@ -35,15 +38,20 @@ describe('graph', function () {
 
     beforeEach(function() {
         modelManager = new ModelManager();
-        const hrBase = fs.readFileSync('./test/codegen/fromcto/data/model/hr_base.cto', 'utf-8');
+        const hrBase = fs.readFileSync(
+            './test/codegen/fromcto/data/model/hr_base.cto',
+            'utf-8'
+        );
         modelManager.addCTOModel(hrBase, 'hr_base.cto');
-        const hr = fs.readFileSync('./test/codegen/fromcto/data/model/hr.cto', 'utf-8');
+        const hr = fs.readFileSync(
+            './test/codegen/fromcto/data/model/hr.cto',
+            'utf-8'
+        );
         modelManager.addCTOModel(hr, 'hr.cto');
     });
 
-
-    describe('#visitor', function () {
-        it('should visit a model manager', function () {
+    describe('#visitor', function() {
+        it('should visit a model manager', function() {
             const visitor = new ConcertoGraphVisitor();
             visitor.should.not.be.null;
             const writer = new InMemoryWriter();
@@ -136,8 +144,7 @@ describe('graph', function () {
 `);
         });
 
-
-        it('should visit find a connected subgraph', function () {
+        it('should visit find a connected subgraph', function() {
             const visitor = new ConcertoGraphVisitor();
             visitor.should.not.be.null;
             const writer = new InMemoryWriter();
@@ -145,14 +152,24 @@ describe('graph', function () {
             const graph = new DirectedGraph();
             modelManager.accept(visitor, { graph });
 
-            const connectedGraph = graph.findConnectedGraph('org.acme.hr@1.0.0.ChangeOfAddress');
-            expect(connectedGraph.hasEdge('org.acme.hr@1.0.0.ChangeOfAddress', 'org.acme.hr@1.0.0.Person'));
+            const connectedGraph = graph.findConnectedGraph(
+                'org.acme.hr@1.0.0.ChangeOfAddress'
+            );
+            expect(
+                connectedGraph.hasEdge(
+                    'org.acme.hr@1.0.0.ChangeOfAddress',
+                    'org.acme.hr@1.0.0.Person'
+                )
+            );
 
-            const filteredModelManager = modelManager
-                .filter(declaration => connectedGraph.hasVertex(declaration.getFullyQualifiedName()));
+            const filteredModelManager = modelManager.filter((declaration) =>
+                connectedGraph.hasVertex(declaration.getFullyQualifiedName())
+            );
 
             expect(filteredModelManager.getModelFiles()).toHaveLength(2);
-            expect(filteredModelManager.getModelFiles()[0].getAllDeclarations()).toHaveLength(5);
+            expect(
+                filteredModelManager.getModelFiles()[0].getAllDeclarations()
+            ).toHaveLength(5);
 
             writer.openFile('graph.mmd');
             connectedGraph.print(writer);
@@ -224,6 +241,98 @@ describe('graph', function () {
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinTelephone\`
+`);
+        });
+
+        it('should visit a model manager and create a dependencyGraph', function() {
+            const visitor = new ConcertoGraphVisitor();
+            visitor.should.not.be.null;
+            const writer = new InMemoryWriter();
+
+            const graph = new DirectedGraph();
+            modelManager.accept(visitor, {
+                graph,
+                createDependencyGraph: true,
+            });
+
+            writer.openFile('graph.mmd');
+            graph.print(writer);
+            writer.closeFile();
+            expect(writer.data.get('graph.mmd')).toEqual(`flowchart LR
+   \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
+   \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Laptop\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Contractor\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
+   \`org.acme.hr@1.0.0.Onboarded\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinTelephone\`
 `);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #118
Adds an option to create a dependency graph. (Does not include references from supertypes to extending types).

### Changes
The `ConcertoGraphVisitor` now optionally supports a parameter, `createDependencyGraph`, that if truthy stops the visitor from creating edges from supertypes to extending types.


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ x Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
