### PR TITLE
feat(rust): support for alias import in codegen

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -383,7 +383,11 @@ class CSharpVisitor {
             }
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
-            fieldType = `${fqn}${field.getModelFile().getActualImportType(fieldType)}`;
+            const modelFile = field.getModelFile();
+            if (modelFile.isImportedType(fieldType)) {
+                fieldType = modelFile.getActualImportType(fieldType);
+            }
+            fieldType = `${fqn}${fieldType}`;
         }
 
         let nullableType = '';

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const { ModelUtil, ModelFile } = require('@accordproject/concerto-core');
+const { ModelUtil } = require('@accordproject/concerto-core');
 const camelCase = require('camelcase');
 const { throwUnrecognizedType } = require('../../../common/util');
 
@@ -384,7 +384,7 @@ class CSharpVisitor {
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
-            if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
+            if (modelFile?.isImportedType?.(fieldType)) {
                 fieldType = modelFile.getImportedType(fieldType);
             }
             fieldType = `${fqn}${fieldType}`;

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const { ModelUtil } = require('@accordproject/concerto-core');
+const { ModelUtil, ModelFile } = require('@accordproject/concerto-core');
 const camelCase = require('camelcase');
 const { throwUnrecognizedType } = require('../../../common/util');
 
@@ -384,7 +384,7 @@ class CSharpVisitor {
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
-            if (modelFile && modelFile.isImportedType(fieldType)) {
+            if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
                 fieldType = modelFile.getActualImportType(fieldType);
             }
             fieldType = `${fqn}${fieldType}`;

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -384,7 +384,7 @@ class CSharpVisitor {
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
-            if (modelFile?.isImportedType?.(fieldType)) {
+            if (modelFile?.isImportedType(fieldType)) {
                 fieldType = modelFile.getImportedType(fieldType);
             }
             fieldType = `${fqn}${fieldType}`;

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -385,7 +385,7 @@ class CSharpVisitor {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
             if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
-                fieldType = modelFile.getActualImportType(fieldType);
+                fieldType = modelFile.getImportedType(fieldType);
             }
             fieldType = `${fqn}${fieldType}`;
         }

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -384,7 +384,7 @@ class CSharpVisitor {
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
-            if (modelFile.isImportedType(fieldType)) {
+            if (modelFile && modelFile.isImportedType(fieldType)) {
                 fieldType = modelFile.getActualImportType(fieldType);
             }
             fieldType = `${fqn}${fieldType}`;

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -383,7 +383,7 @@ class CSharpVisitor {
             }
         } else if (!field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
-            fieldType = `${fqn}${fieldType}`;
+            fieldType = `${fqn}${field.getModelFile().getActualImportType(fieldType)}`;
         }
 
         let nullableType = '';

--- a/lib/codegen/fromcto/java/javavisitor.js
+++ b/lib/codegen/fromcto/java/javavisitor.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const { ModelFile } = require('@accordproject/concerto-core');
 const EmptyPlugin = require('./emptyplugin');
 const ModelUtil = require('@accordproject/concerto-core').ModelUtil;
 const util = require('util');
@@ -267,9 +268,14 @@ class JavaVisitor {
         if(field.isArray()) {
             array = '[]';
         }
-
-        const fieldType = this.toJavaType(field.getType()) + array;
-
+        let fieldType = field.getType();
+        if (!ModelUtil.isPrimitiveType(fieldType)) {
+            const modelFile = field.getModelFile();
+            if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
+                fieldType = modelFile.getActualImportType(fieldType);
+            }
+        }
+        fieldType = this.toJavaType(fieldType) + array;
         const fieldName = field.getName();
         const getterName = 'get' + this.capitalizeFirstLetter(fieldName);
         const setterName = 'set' + this.capitalizeFirstLetter(fieldName);

--- a/lib/codegen/fromcto/java/javavisitor.js
+++ b/lib/codegen/fromcto/java/javavisitor.js
@@ -270,7 +270,7 @@ class JavaVisitor {
         let fieldType = field.getType();
         if (!ModelUtil.isPrimitiveType(fieldType)) {
             const modelFile = field.getModelFile();
-            if (modelFile?.isImportedType?.(fieldType)) {
+            if (modelFile?.isImportedType(fieldType)) {
                 fieldType = modelFile.getImportedType(fieldType);
             }
         }

--- a/lib/codegen/fromcto/java/javavisitor.js
+++ b/lib/codegen/fromcto/java/javavisitor.js
@@ -272,7 +272,7 @@ class JavaVisitor {
         if (!ModelUtil.isPrimitiveType(fieldType)) {
             const modelFile = field.getModelFile();
             if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
-                fieldType = modelFile.getActualImportType(fieldType);
+                fieldType = modelFile.getImportedType(fieldType);
             }
         }
         fieldType = this.toJavaType(fieldType) + array;

--- a/lib/codegen/fromcto/java/javavisitor.js
+++ b/lib/codegen/fromcto/java/javavisitor.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-const { ModelFile } = require('@accordproject/concerto-core');
 const EmptyPlugin = require('./emptyplugin');
 const ModelUtil = require('@accordproject/concerto-core').ModelUtil;
 const util = require('util');
@@ -271,7 +270,7 @@ class JavaVisitor {
         let fieldType = field.getType();
         if (!ModelUtil.isPrimitiveType(fieldType)) {
             const modelFile = field.getModelFile();
-            if (modelFile instanceof ModelFile && modelFile.isImportedType(fieldType)) {
+            if (modelFile?.isImportedType?.(fieldType)) {
                 fieldType = modelFile.getImportedType(fieldType);
             }
         }

--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -211,7 +211,16 @@ class RustVisitor {
      * @private
      */
     visitField(field, parameters) {
-        let type = this.toRustType(field.type);
+        let type = field.type;
+        if (!ModelUtil.isPrimitiveType(field.type)) {
+            const modelFile = field.getModelFile();
+            if (modelFile?.isImportedType(type)) {
+                type = modelFile.getImportedType(type);
+            }
+            console.log(type);
+        }
+        type = this.toRustType(type);
+        
         if (field.isArray?.()) {
             type = `Vec<${type}>`;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.23.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@accordproject/concerto-core": "3.18.0",
+                "@accordproject/concerto-core": "3.19.0",
                 "@accordproject/concerto-util": "3.18.0",
                 "@accordproject/concerto-vocabulary": "3.18.0",
                 "@openapi-contrib/openapi-schema-to-json-schema": "5.1.0",
@@ -61,13 +61,14 @@
             }
         },
         "node_modules/@accordproject/concerto-core": {
-            "version": "3.18.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.18.0.tgz",
-            "integrity": "sha512-a1f1Z79oJEBrW+eYa65+R14TLv6Mdom/5tny7sBWV/RT2S3iCUCop6jGSpycADgvIkrDySnW4F3hSct4+0ZHLg==",
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.0.tgz",
+            "integrity": "sha512-zgAV8s5e+I4wGJjYeQkYl/5c3/Ew8ZbQWunbICu2obtoW4xmvPJ7gWBRg2n3lrsCYuEde7eMT8tRZ8Kcgwuh7w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@accordproject/concerto-cto": "3.18.0",
+                "@accordproject/concerto-cto": "3.19.0",
                 "@accordproject/concerto-metamodel": "3.10.0",
-                "@accordproject/concerto-util": "3.18.0",
+                "@accordproject/concerto-util": "3.19.0",
                 "dayjs": "1.11.10",
                 "debug": "4.3.4",
                 "lorem-ipsum": "2.0.8",
@@ -82,10 +83,44 @@
                 "npm": ">=8"
             }
         },
+        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.19.0.tgz",
+            "integrity": "sha512-eA8O2IcEmnOdGTu2bWeSFQMSSHQr7vJ/Gzhv0cWxnh41wxKhmfoBK/BmEZgyJi6dI7HufKkat+p2B76MIwCqOA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@accordproject/concerto-metamodel": "3.10.0",
+                "@accordproject/concerto-util": "3.19.0",
+                "path-browserify": "1.0.1"
+            },
+            "engines": {
+                "node": ">=16",
+                "npm": ">=8"
+            }
+        },
+        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.0.tgz",
+            "integrity": "sha512-zadhEhKoVDuRcmUZGH5xbgV2Am1zv8jMPJaedWadiSyqw2qif95MZvKg7DEIdSohQvcfJ5z53iPJqsdmfauJAA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@supercharge/promise-pool": "1.7.0",
+                "axios": "1.6.8",
+                "colors": "1.4.0",
+                "debug": "4.3.4",
+                "json-colorizer": "2.2.2",
+                "slash": "3.0.0"
+            },
+            "engines": {
+                "node": ">=16",
+                "npm": ">=8"
+            }
+        },
         "node_modules/@accordproject/concerto-cto": {
             "version": "3.18.0",
             "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.18.0.tgz",
             "integrity": "sha512-zrE42ip6Tfavyr/Hox2AIc785McobYjK756KR1bOX4aUWZQtQTpzBZKIwM4wsfsb7HZ+sLxEkzFYidk2TCguBw==",
+            "dev": true,
             "dependencies": {
                 "@accordproject/concerto-metamodel": "3.10.0",
                 "@accordproject/concerto-util": "3.18.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "webpack-cli": "4.9.1"
     },
     "dependencies": {
-        "@accordproject/concerto-core": "3.18.0",
+        "@accordproject/concerto-core": "3.19.0",
         "@accordproject/concerto-util": "3.18.0",
         "@accordproject/concerto-vocabulary": "3.18.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "5.1.0",

--- a/test/codegen/codegen.js
+++ b/test/codegen/codegen.js
@@ -31,6 +31,7 @@ describe('codegen', function () {
 
     before(function() {
         process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
+        process.env.IMPORT_ALIASING = 'true';
     });
 
     beforeEach(function() {

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -787,7 +787,7 @@ public class SampleModel : Concept {
         });
 
         it('should handle imported field which is aliased in a concept', () => {
-            const modelManager = new ModelManager({ enableAliasedType: true });
+            const modelManager = new ModelManager({ importAliasing: true });
             modelManager.addCTOModel(`
             namespace org.example.basic
             concept file{
@@ -818,7 +818,7 @@ public class SampleModel : Concept {
         });
 
         it('should handle imported field which extended in concept', () => {
-            const modelManager = new ModelManager({ enableAliasedType: true });
+            const modelManager = new ModelManager({ importAliasing: true });
             modelManager.addCTOModel(`
             namespace org.example.basic
             concept file{

--- a/test/codegen/fromcto/java/javavisitor.js
+++ b/test/codegen/fromcto/java/javavisitor.js
@@ -583,7 +583,7 @@ describe('JavaVisitor', function () {
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
 
-        it('should write a line getting a field of type aliased import', ()=> {
+        it('should write a line getting a field of type aliased import', () => {
             // Document aliased as Doc
             let mockField = sinon.createStubInstance(Field);
             let mockModelFile = sinon.createStubInstance(ModelFile);
@@ -596,7 +596,7 @@ describe('JavaVisitor', function () {
             mockModelFile.isImportedType.returns(true);
             mockModelFile.getImportedType.returns('Document');
 
-            javaVisit.visitField(mockField , Object.assign({},param,{mode:'getter'}));
+            javaVisit.visitField(mockField, Object.assign({}, param, { mode: 'getter' }));
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public Document getBob() {']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, 'return this.Bob;']);

--- a/test/codegen/fromcto/java/javavisitor.js
+++ b/test/codegen/fromcto/java/javavisitor.js
@@ -582,6 +582,26 @@ describe('JavaVisitor', function () {
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, 'return this.Bob;']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
+
+        it('should write a line getting a field of type aliased import', ()=> {
+            // Document aliased as Doc
+            let mockField = sinon.createStubInstance(Field);
+            let mockModelFile = sinon.createStubInstance(ModelFile);
+
+            mockField.isField.returns(true);
+            mockField.isArray.returns(false);
+            mockField.getName.returns('Bob');
+            mockField.getType.returns('Doc');
+            mockField.getModelFile.returns(mockModelFile);
+            mockModelFile.isImportedType.returns(true);
+            mockModelFile.getImportedType.returns('Document');
+
+            javaVisit.visitField(mockField , Object.assign({},param,{mode:'getter'}));
+            param.fileWriter.writeLine.callCount.should.deep.equal(3);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public Document getBob() {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, 'return this.Bob;']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+        });
     });
 
     describe('visitEnumValueDeclaration', () => {

--- a/test/codegen/fromcto/java/javavisitor.js
+++ b/test/codegen/fromcto/java/javavisitor.js
@@ -467,9 +467,10 @@ describe('JavaVisitor', function () {
 
             const mockField             = sinon.createStubInstance(Field);
             const getType               = sinon.stub();
+            const isImportedType        = sinon.stub();
 
             mockField.ast = { type: { name: 'Dummy Value'} };
-            mockField.getModelFile.returns({ getType: getType });
+            mockField.getModelFile.returns({ getType: getType, isImportedType: isImportedType });
 
             const mockMapDeclaration    = sinon.createStubInstance(MapDeclaration);
             const getKeyType            = sinon.stub();
@@ -481,6 +482,7 @@ describe('JavaVisitor', function () {
             getType.returns(mockMapDeclaration);
             getKeyType.returns('String');
             getValueType.returns('String');
+            isImportedType.returns(false);
             mockField.getName.returns('Map1');
             mockMapDeclaration.getName.returns('Map1');
             mockMapDeclaration.isMapDeclaration.returns(true);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
This Pr handles support for aliasing imports in rust language. CTO file using aliasing should be correctly exported to rust format.



### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
