### PR TITLE
fix(filewriter): disable visitor from calling the file writer

### DIFF
--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -197,7 +197,6 @@ class DiagramVisitor {
      */
     visitScalarField(field, parameters) {
         this.visitField(field.getScalarField(), parameters);
-        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
     }
 
     /**
@@ -222,7 +221,6 @@ class DiagramVisitor {
         if(field.isArray()) {
             array = '[]';
         }
-        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         parameters.fileWriter.writeLine(1, '+ ' + field.getType() + array + ' ' + field.getName());
     }
 
@@ -233,7 +231,6 @@ class DiagramVisitor {
      * @protected
      */
     visitEnumValueDeclaration(enumValueDeclaration, parameters) {
-        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         parameters.fileWriter.writeLine(1, '+ ' + enumValueDeclaration.getName());
     }
 

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -260,7 +260,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitScalarField(scalar, parameters) {
-        super.visitScalarField(scalar, parameters);
+        scalar.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         parameters.graph.addEdge(parameters.stack.slice(-1), scalar.getFullyQualifiedTypeName());
     }
 
@@ -271,7 +271,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitField(field, parameters) {
-        super.visitField(field, parameters);
+        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         if (!ModelUtil.isPrimitiveType(field.getFullyQualifiedTypeName())) {
             parameters.graph.addEdge(parameters.stack.slice(-1), field.getFullyQualifiedTypeName());
         }
@@ -284,7 +284,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitRelationship(relationship, parameters) {
-        super.visitRelationship(relationship, parameters);
+        relationship.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         parameters.graph.addEdge(parameters.stack.slice(-1), relationship.getFullyQualifiedTypeName());
     }
 
@@ -295,7 +295,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitEnumValueDeclaration(enumValueDeclaration, parameters) {
-        super.visitEnumValueDeclaration(enumValueDeclaration, parameters);
+        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         return;
     }
 }

--- a/test/codegen/fromcto/data/model/hr.cto
+++ b/test/codegen/fromcto/data/model/hr.cto
@@ -7,6 +7,7 @@ map CompanyProperties {
     o String
 }
 
+@decorated
 map EmployeeLoginTimes {
     o String
     o Time

--- a/test/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/test/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -543,7 +543,6 @@ describe('PlantUMLVisitor', function () {
             let mockField = sinon.createStubInstance(Field);
             mockField.isField.returns(true);
             mockField.getType.returns('string');
-            mockField.getDecorators.returns([]);
             mockField.getName.returns('Bob');
             mockField.getParent.returns({
                 getFullyQualifiedName: () => { return 'org.acme.Human'; },
@@ -562,7 +561,6 @@ describe('PlantUMLVisitor', function () {
             let mockField = sinon.createStubInstance(Field);
             mockField.isField.returns(true);
             mockField.getType.returns('string');
-            mockField.getDecorators.returns([]);
             mockField.getName.returns('Bob');
             mockField.isArray.returns(true);
             mockField.getParent.returns({
@@ -583,7 +581,6 @@ describe('PlantUMLVisitor', function () {
 
             let mockEnumValueDecl = sinon.createStubInstance(EnumValueDeclaration);
             mockEnumValueDecl.isEnumValue.returns(true);
-            mockEnumValueDecl.getDecorators.returns([]);
             mockEnumValueDecl.getName.returns('Bob');
 
             plantUMLvisitor.visitEnumValueDeclaration(mockEnumValueDecl, param);

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -22,7 +22,6 @@ const {
 const { ModelManager } = require('@accordproject/concerto-core');
 const fs = require('fs');
 const { expect } = require('expect');
-const sinon = require('sinon');
 
 const chai = require('chai');
 const { InMemoryWriter } = require('@accordproject/concerto-util');
@@ -32,7 +31,6 @@ chai.use(require('chai-things'));
 
 describe('graph', function() {
     let modelManager = null;
-    let mockFileWriter;
 
     before(function() {
         process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
@@ -50,7 +48,6 @@ describe('graph', function() {
             'utf-8'
         );
         modelManager.addCTOModel(hr, 'hr.cto');
-        mockFileWriter = sinon.createStubInstance(InMemoryWriter);
     });
 
     describe('#visitor', function() {
@@ -60,7 +57,7 @@ describe('graph', function() {
             const writer = new InMemoryWriter();
 
             const graph = new DirectedGraph();
-            modelManager.accept(visitor, { graph, fileWriter: mockFileWriter });
+            modelManager.accept(visitor, { graph });
 
             writer.openFile('graph.mmd');
             graph.print(writer);
@@ -157,7 +154,7 @@ describe('graph', function() {
             const writer = new InMemoryWriter();
 
             const graph = new DirectedGraph();
-            modelManager.accept(visitor, { graph, fileWriter: mockFileWriter });
+            modelManager.accept(visitor, { graph });
 
             const connectedGraph = graph.findConnectedGraph(
                 'org.acme.hr@1.0.0.ChangeOfAddress'
@@ -261,8 +258,7 @@ describe('graph', function() {
             const graph = new DirectedGraph();
             modelManager.accept(visitor, {
                 graph,
-                createDependencyGraph: true,
-                fileWriter: mockFileWriter
+                createDependencyGraph: true
             });
 
             writer.openFile('graph.mmd');


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<[125](https://github.com/accordproject/concerto-codegen/issues/125)>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Avoid running `filewriter` when adding decorators to directed graph


### Related Issues
- Pull Request #<[126](https://github.com/accordproject/concerto-codegen/pull/126)>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
