### PR TITLE
fix(graph): add decorators that ref types to graph

### DIFF
--- a/lib/codegen/fromcto/odata/odatavisitor.js
+++ b/lib/codegen/fromcto/odata/odatavisitor.js
@@ -238,7 +238,7 @@ class ODataVisitor {
             default:
                 argType = 'String';
             }
-            parameters.fileWriter.writeLine(4, `<Annotation Term="${decorator.getName()}${index}" ${argType}="${arg.toString()}" />`);
+            parameters.fileWriter.writeLine(4, `<Annotation Term="${decorator.getName()}${index}" ${argType}="${typeof arg === 'object' ? arg.name : arg.toString()}" />`);
         });
         return null;
     }

--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -197,6 +197,7 @@ class DiagramVisitor {
      */
     visitScalarField(field, parameters) {
         this.visitField(field.getScalarField(), parameters);
+        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
     }
 
     /**
@@ -221,7 +222,10 @@ class DiagramVisitor {
         if(field.isArray()) {
             array = '[]';
         }
-        parameters.fileWriter.writeLine(1, '+ ' + field.getType() + array + ' ' + field.getName());
+        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        if(parameters.fileWriter) {
+            parameters.fileWriter.writeLine(1, '+ ' + field.getType() + array + ' ' + field.getName());
+        }
     }
 
     /**
@@ -231,7 +235,10 @@ class DiagramVisitor {
      * @protected
      */
     visitEnumValueDeclaration(enumValueDeclaration, parameters) {
-        parameters.fileWriter.writeLine(1, '+ ' + enumValueDeclaration.getName());
+        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        if(parameters.fileWriter) {
+            parameters.fileWriter.writeLine(1, '+ ' + enumValueDeclaration.getName());
+        }
     }
 
     /**
@@ -257,9 +264,11 @@ class DiagramVisitor {
             if (parameters.hideBaseModel && isBaseModel){
                 return;
             }
-            const source = this.escapeString(classDeclaration.getFullyQualifiedName());
-            const target = this.escapeString(classDeclaration.getSuperType());
-            parameters.fileWriter.writeLine(0, `${source} ${DiagramVisitor.INHERITANCE} ${target}`);
+            if(parameters.fileWriter) {
+                const source = this.escapeString(classDeclaration.getFullyQualifiedName());
+                const target = this.escapeString(classDeclaration.getSuperType());
+                parameters.fileWriter.writeLine(0, `${source} ${DiagramVisitor.INHERITANCE} ${target}`);
+            }
         }
     }
 }

--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -197,7 +197,6 @@ class DiagramVisitor {
      */
     visitScalarField(field, parameters) {
         this.visitField(field.getScalarField(), parameters);
-        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
     }
 
     /**

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -212,13 +212,16 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitDecorator(decorator, parameters) {
+        super.visitDecorator(decorator, parameters);
         const parent = decorator.getParent();
         const modelFile = parent.getModelFile();
         decorator.getArguments()?.forEach(argument => {
-            const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
-            if (fqn) {
-                parameters.graph.addVertex(fqn);
-                (parent === modelFile) ? parameters.graph.addEdge(parent.getNamespace(), fqn) : parameters.graph.addEdge(parent.getFullyQualifiedName(), fqn);
+            if(argument.name) {
+                const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
+                if (fqn) {
+                    parameters.graph.addVertex(fqn);
+                    (parent === modelFile) ? parameters.graph.addEdge(parent.getNamespace(), fqn) : parameters.graph.addEdge(parent.getFullyQualifiedName(), fqn);
+                }
             }
         });
     }
@@ -260,7 +263,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitScalarField(scalar, parameters) {
-        scalar.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitScalarField(scalar, parameters);
         parameters.graph.addEdge(parameters.stack.slice(-1), scalar.getFullyQualifiedTypeName());
     }
 
@@ -271,7 +274,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitField(field, parameters) {
-        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitField(field, parameters);
         if (!ModelUtil.isPrimitiveType(field.getFullyQualifiedTypeName())) {
             parameters.graph.addEdge(parameters.stack.slice(-1), field.getFullyQualifiedTypeName());
         }
@@ -284,7 +287,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitRelationship(relationship, parameters) {
-        relationship.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitRelationship(relationship, parameters);
         parameters.graph.addEdge(parameters.stack.slice(-1), relationship.getFullyQualifiedTypeName());
     }
 
@@ -295,7 +298,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitEnumValueDeclaration(enumValueDeclaration, parameters) {
-        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitEnumValueDeclaration(enumValueDeclaration, parameters);
         return;
     }
 }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -70,6 +70,12 @@ protocol MyProtocol {
 
    import idl "concerto@1.0.0.avdl";
    
+   record Category {
+   }
+
+   record GeneralCategory {
+   }
+
    enum State {
       MA,
       NY,
@@ -334,6 +340,18 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   "key": "org.acme.hr.base.cs",
   "value": "namespace org.acme.hr.base;
 using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = null, Name = "Category")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Category : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.base.Category";
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = null, Name = "GeneralCategory")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class GeneralCategory : Category {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.base.GeneralCategory";
+}
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum State {
       MA,
@@ -557,6 +575,12 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 package org_acme_hr_base
 import "concerto_1_0_0";
    
+type Category struct {
+   concerto_1_0_0.Concept
+}
+type GeneralCategory struct {
+   Category
+}
 type State int
 const (
    MA State = 1 + iota
@@ -680,8 +704,15 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 {
   "key": "model.gql",
   "value": "directive @resource on OBJECT | FIELD_DEFINITION
+directive @category on OBJECT | FIELD_DEFINITION
 scalar DateTime
 # namespace org.acme.hr.base
+type Category {
+   _: Boolean
+}
+type GeneralCategory {
+   _: Boolean
+}
 enum State {
    MA
    NY
@@ -776,7 +807,7 @@ type Person @resource {
    nextOfKin: NextOfKin!
    _identifier: String!
 }
-type Employee {
+type Employee @category {
    employeeId: String!
    salary: Int!
    numDependents: Int!
@@ -972,6 +1003,46 @@ public abstract class Event extends Concept {
 
 exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 6`] = `
 {
+  "key": "org/acme/hr/base/Category.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr.base;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class Category extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 7`] = `
+{
+  "key": "org/acme/hr/base/GeneralCategory.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr.base;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class GeneralCategory extends Category {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 8`] = `
+{
   "key": "org/acme/hr/base/State.java",
   "value": "// this code is generated and should not be modified
 package org.acme.hr.base;
@@ -990,7 +1061,7 @@ public enum State {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 7`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 9`] = `
 {
   "key": "org/acme/hr/base/TShirtSizeType.java",
   "value": "// this code is generated and should not be modified
@@ -1007,7 +1078,7 @@ public enum TShirtSizeType {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 8`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 10`] = `
 {
   "key": "org/acme/hr/base/Address.java",
   "value": "// this code is generated and should not be modified
@@ -1062,7 +1133,7 @@ public class Address extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 9`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 11`] = `
 {
   "key": "org/acme/hr/base/Level.java",
   "value": "// this code is generated and should not be modified
@@ -1076,7 +1147,7 @@ public enum Level {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 10`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 12`] = `
 {
   "key": "org/acme/hr/Company.java",
   "value": "// this code is generated and should not be modified
@@ -1088,6 +1159,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1153,7 +1225,7 @@ public class Company extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 11`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 13`] = `
 {
   "key": "org/acme/hr/Department.java",
   "value": "// this code is generated and should not be modified
@@ -1173,7 +1245,7 @@ public enum Department {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 12`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 14`] = `
 {
   "key": "org/acme/hr/Equipment.java",
   "value": "// this code is generated and should not be modified
@@ -1185,6 +1257,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1213,7 +1286,7 @@ public abstract class Equipment extends Asset {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 13`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 15`] = `
 {
   "key": "org/acme/hr/LaptopMake.java",
   "value": "// this code is generated and should not be modified
@@ -1229,7 +1302,7 @@ public enum LaptopMake {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 14`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 16`] = `
 {
   "key": "org/acme/hr/Laptop.java",
   "value": "// this code is generated and should not be modified
@@ -1241,6 +1314,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1269,7 +1343,7 @@ public class Laptop extends Equipment {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 15`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 17`] = `
 {
   "key": "org/acme/hr/Person.java",
   "value": "// this code is generated and should not be modified
@@ -1281,6 +1355,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1367,7 +1442,7 @@ public abstract class Person extends Participant {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 16`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 18`] = `
 {
   "key": "org/acme/hr/Employee.java",
   "value": "// this code is generated and should not be modified
@@ -1379,6 +1454,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1456,7 +1532,7 @@ public class Employee extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 17`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 19`] = `
 {
   "key": "org/acme/hr/Contractor.java",
   "value": "// this code is generated and should not be modified
@@ -1468,6 +1544,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1503,7 +1580,7 @@ public class Contractor extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 18`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 20`] = `
 {
   "key": "org/acme/hr/Manager.java",
   "value": "// this code is generated and should not be modified
@@ -1515,6 +1592,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1543,7 +1621,7 @@ public class Manager extends Employee {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 19`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 21`] = `
 {
   "key": "org/acme/hr/CompanyEvent.java",
   "value": "// this code is generated and should not be modified
@@ -1555,6 +1633,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1568,7 +1647,7 @@ public class CompanyEvent extends Event {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 20`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 22`] = `
 {
   "key": "org/acme/hr/Onboarded.java",
   "value": "// this code is generated and should not be modified
@@ -1580,6 +1659,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1600,7 +1680,7 @@ public class Onboarded extends CompanyEvent {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 21`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 23`] = `
 {
   "key": "org/acme/hr/ChangeOfAddress.java",
   "value": "// this code is generated and should not be modified
@@ -1612,6 +1692,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1645,6 +1726,38 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   "value": "{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "org.acme.hr.base.Category": {
+      "title": "Category",
+      "description": "An instance of org.acme.hr.base.Category",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.base.Category",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.base\\\\.Category$",
+          "description": "The class identifier for org.acme.hr.base.Category"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
+    "org.acme.hr.base.GeneralCategory": {
+      "title": "GeneralCategory",
+      "description": "An instance of org.acme.hr.base.GeneralCategory",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.base.GeneralCategory",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.base\\\\.GeneralCategory$",
+          "description": "The class identifier for org.acme.hr.base.GeneralCategory"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
     "org.acme.hr.base.State": {
       "title": "State",
       "description": "An instance of org.acme.hr.base.State",
@@ -2056,7 +2169,16 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
         "height",
         "dob",
         "nextOfKin"
-      ]
+      ],
+      "$decorators": {
+        "category": [
+          {
+            "type": "Identifier",
+            "name": "GeneralCategory",
+            "array": false
+          }
+        ]
+      }
     },
     "org.acme.hr.Contractor": {
       "title": "Contractor",
@@ -2336,7 +2458,7 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   "value": "# Namespace org.acme.hr.base
 
 ## Overview
-- 1 concepts
+- 3 concepts
 - 3 enumerations
 - 1 maps
 - 2 scalars
@@ -2344,7 +2466,7 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 - 0 participants
 - 0 transactions
 - 0 events
-- 7 total declarations
+- 9 total declarations
 
 ## Imports
 - concerto@1.0.0.Concept
@@ -2356,6 +2478,13 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 ## Diagram
 \`\`\`mermaid
 classDiagram
+class \`org.acme.hr.base.Category\`
+<< concept>> \`org.acme.hr.base.Category\`
+
+class \`org.acme.hr.base.GeneralCategory\`
+<< concept>> \`org.acme.hr.base.GeneralCategory\`
+
+\`org.acme.hr.base.GeneralCategory\` --|> \`org.acme.hr.base.Category\`
 class \`org.acme.hr.base.State\` {
 << enumeration>>
    + MA
@@ -2414,6 +2543,7 @@ class \`org.acme.hr.base.Level\`
 - org.acme.hr.base.Time
 - org.acme.hr.base.EmployeeTShirtSizes
 - org.acme.hr.base.Level
+- org.acme.hr.base.GeneralCategory
 - concerto@1.0.0.Concept
 - concerto@1.0.0.Asset
 - concerto@1.0.0.Transaction
@@ -2581,6 +2711,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 {
   "key": "model.mmd",
   "value": "classDiagram
+class \`org.acme.hr.base.Category\`
+<< concept>> \`org.acme.hr.base.Category\`
+
+\`org.acme.hr.base.Category\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr.base.GeneralCategory\`
+<< concept>> \`org.acme.hr.base.GeneralCategory\`
+
+\`org.acme.hr.base.GeneralCategory\` --|> \`org.acme.hr.base.Category\`
 class \`org.acme.hr.base.State\` {
 << enumeration>>
    + MA
@@ -2810,6 +2948,10 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 </edmx:Reference>
 <edmx:DataServices>
    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.acme.hr.base">
+      <ComplexType Name="Category" Abstract="true" BaseType="concerto.Concept">
+      </ComplexType>
+      <ComplexType Name="GeneralCategory" Abstract="true" BaseType="org.acme.hr.base.Category">
+      </ComplexType>
       <EnumType Name="State">
          <Member Name="MA">
          </Member>
@@ -2968,6 +3110,8 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
          </Property>
       </EntityType>
       <EntityType Name="Employee"  BaseType="org.acme.hr.Person">
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="[object Object]" />
          <Property Name="employeeId" Type="Edm.String"  >
          </Property>
          <Property Name="salary" Type="Edm.Int64"  >
@@ -3035,6 +3179,38 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   },
   "components": {
     "schemas": {
+      "org.acme.hr.base.Category": {
+        "title": "Category",
+        "description": "An instance of org.acme.hr.base.Category",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.base.Category",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.base\\\\.Category$",
+            "description": "The class identifier for org.acme.hr.base.Category"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "org.acme.hr.base.GeneralCategory": {
+        "title": "GeneralCategory",
+        "description": "An instance of org.acme.hr.base.GeneralCategory",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.base.GeneralCategory",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.base\\\\.GeneralCategory$",
+            "description": "The class identifier for org.acme.hr.base.GeneralCategory"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
       "org.acme.hr.base.State": {
         "title": "State",
         "description": "An instance of org.acme.hr.base.State",
@@ -3446,7 +3622,16 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
           "height",
           "dob",
           "nextOfKin"
-        ]
+        ],
+        "$decorators": {
+          "category": [
+            {
+              "type": "Identifier",
+              "name": "GeneralCategory",
+              "array": false
+            }
+          ]
+        }
       },
       "org.acme.hr.Contractor": {
         "title": "Contractor",
@@ -3976,6 +4161,12 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 title
 Model
 endtitle
+class org.acme.hr.base.Category {
+}
+org.acme.hr.base.Category --|> concerto_1_0_0.Concept
+class org.acme.hr.base.GeneralCategory {
+}
+org.acme.hr.base.GeneralCategory --|> org.acme.hr.base.Category
 class org.acme.hr.base.State << (E,grey) >> {
    + MA
    + NY
@@ -4490,6 +4681,22 @@ use crate::concerto_1_0_0::*;
 use std::collections::HashMap;
 use crate::utils::*;
    
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GeneralCategory {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum State {
    #[allow(non_camel_case_types)]
@@ -5083,6 +5290,7 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	ICategory,
 	State,
 	TShirtSizeType,
 	IAddress,
@@ -5119,7 +5327,8 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IAddress | 
+export type ConceptUnion = ICategory | 
+IAddress | 
 ICompany;
 
 export interface IAsset extends IConcept {
@@ -5188,9 +5397,19 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 // Generated code for namespace: org.acme.hr.base
 
 // imports
+
+// Warning: Beware of circular dependencies when modifying these imports
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
+export interface ICategory extends IConcept {
+}
+
+export type CategoryUnion = IGeneralCategory;
+
+export interface IGeneralCategory extends ICategory {
+}
+
 export enum State {
    MA = 'MA',
    NY = 'NY',
@@ -5350,6 +5569,8 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 locale: en
 namespace: org.acme.hr.base
 declarations:
+  - Category: Category
+  - GeneralCategory: General Category
   - State: State
     properties:
       - MA: MA of the State
@@ -5599,6 +5820,24 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 xmlns:concerto="concerto"
 >
 <xs:import namespace="concerto" schemaLocation="concerto@1.0.0.xsd"/>
+<xs:complexType name="Category">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Category" type="org.acme.hr.base:Category"/>
+<xs:complexType name="GeneralCategory">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr.base:Category">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="GeneralCategory" type="org.acme.hr.base:GeneralCategory"/>
 <xs:simpleType name="State">
    <xs:restriction base="xs:string">
       <xs:enumeration value="MA"/>
@@ -5892,6 +6131,13 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 {
   "key": "model.mmd",
   "value": "classDiagram
+class \`org.acme.hr.base@1.0.0.Category\`
+<< concept>> \`org.acme.hr.base@1.0.0.Category\`
+
+class \`org.acme.hr.base@1.0.0.GeneralCategory\`
+<< concept>> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+
+\`org.acme.hr.base@1.0.0.GeneralCategory\` --|> \`org.acme.hr.base@1.0.0.Category\`
 class \`org.acme.hr.base@1.0.0.State\` {
 << enumeration>>
    + MA
@@ -6087,6 +6333,11 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 title
 Model
 endtitle
+class org.acme.hr.base_1_0_0.Category {
+}
+class org.acme.hr.base_1_0_0.GeneralCategory {
+}
+org.acme.hr.base_1_0_0.GeneralCategory --|> org.acme.hr.base_1_0_0.Category
 class org.acme.hr.base_1_0_0.State << (E,grey) >> {
    + MA
    + NY
@@ -6288,6 +6539,12 @@ protocol MyProtocol {
 
    import idl "concerto@1.0.0.avdl";
    
+   record Category {
+   }
+
+   record GeneralCategory {
+   }
+
    enum State {
       MA,
       NY,
@@ -6552,6 +6809,18 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "key": "org.acme.hr.base@1.0.0.cs",
   "value": "namespace org.acme.hr.base;
 using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = "1.0.0", Name = "Category")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Category : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.base@1.0.0.Category";
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = "1.0.0", Name = "GeneralCategory")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class GeneralCategory : Category {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.base@1.0.0.GeneralCategory";
+}
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum State {
       MA,
@@ -6775,6 +7044,12 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 package org_acme_hr_base_1_0_0
 import "concerto_1_0_0";
    
+type Category struct {
+   concerto_1_0_0.Concept
+}
+type GeneralCategory struct {
+   Category
+}
 type State int
 const (
    MA State = 1 + iota
@@ -6898,8 +7173,15 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 {
   "key": "model.gql",
   "value": "directive @resource on OBJECT | FIELD_DEFINITION
+directive @category on OBJECT | FIELD_DEFINITION
 scalar DateTime
 # namespace org.acme.hr.base@1.0.0
+type Category {
+   _: Boolean
+}
+type GeneralCategory {
+   _: Boolean
+}
 enum State {
    MA
    NY
@@ -6994,7 +7276,7 @@ type Person @resource {
    nextOfKin: NextOfKin!
    _identifier: String!
 }
-type Employee {
+type Employee @category {
    employeeId: String!
    salary: Int!
    numDependents: Int!
@@ -7190,6 +7472,46 @@ public abstract class Event extends Concept {
 
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 6`] = `
 {
+  "key": "org/acme/hr/base/Category.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr.base;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class Category extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 7`] = `
+{
+  "key": "org/acme/hr/base/GeneralCategory.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr.base;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class GeneralCategory extends Category {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 8`] = `
+{
   "key": "org/acme/hr/base/State.java",
   "value": "// this code is generated and should not be modified
 package org.acme.hr.base;
@@ -7208,7 +7530,7 @@ public enum State {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 7`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 9`] = `
 {
   "key": "org/acme/hr/base/TShirtSizeType.java",
   "value": "// this code is generated and should not be modified
@@ -7225,7 +7547,7 @@ public enum TShirtSizeType {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 8`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 10`] = `
 {
   "key": "org/acme/hr/base/Address.java",
   "value": "// this code is generated and should not be modified
@@ -7280,7 +7602,7 @@ public class Address extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 9`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 11`] = `
 {
   "key": "org/acme/hr/base/Level.java",
   "value": "// this code is generated and should not be modified
@@ -7294,7 +7616,7 @@ public enum Level {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 10`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 12`] = `
 {
   "key": "org/acme/hr/Company.java",
   "value": "// this code is generated and should not be modified
@@ -7306,6 +7628,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7371,7 +7694,7 @@ public class Company extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 11`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 13`] = `
 {
   "key": "org/acme/hr/Department.java",
   "value": "// this code is generated and should not be modified
@@ -7391,7 +7714,7 @@ public enum Department {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 12`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 14`] = `
 {
   "key": "org/acme/hr/Equipment.java",
   "value": "// this code is generated and should not be modified
@@ -7403,6 +7726,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7431,7 +7755,7 @@ public abstract class Equipment extends Asset {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 13`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 15`] = `
 {
   "key": "org/acme/hr/LaptopMake.java",
   "value": "// this code is generated and should not be modified
@@ -7447,7 +7771,7 @@ public enum LaptopMake {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 14`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 16`] = `
 {
   "key": "org/acme/hr/Laptop.java",
   "value": "// this code is generated and should not be modified
@@ -7459,6 +7783,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7487,7 +7812,7 @@ public class Laptop extends Equipment {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 15`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 17`] = `
 {
   "key": "org/acme/hr/Person.java",
   "value": "// this code is generated and should not be modified
@@ -7499,6 +7824,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7585,7 +7911,7 @@ public abstract class Person extends Participant {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 16`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 18`] = `
 {
   "key": "org/acme/hr/Employee.java",
   "value": "// this code is generated and should not be modified
@@ -7597,6 +7923,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7674,7 +8001,7 @@ public class Employee extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 17`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 19`] = `
 {
   "key": "org/acme/hr/Contractor.java",
   "value": "// this code is generated and should not be modified
@@ -7686,6 +8013,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7721,7 +8049,7 @@ public class Contractor extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 18`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 20`] = `
 {
   "key": "org/acme/hr/Manager.java",
   "value": "// this code is generated and should not be modified
@@ -7733,6 +8061,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7761,7 +8090,7 @@ public class Manager extends Employee {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 19`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 21`] = `
 {
   "key": "org/acme/hr/CompanyEvent.java",
   "value": "// this code is generated and should not be modified
@@ -7773,6 +8102,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7786,7 +8116,7 @@ public class CompanyEvent extends Event {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 20`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 22`] = `
 {
   "key": "org/acme/hr/Onboarded.java",
   "value": "// this code is generated and should not be modified
@@ -7798,6 +8128,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7818,7 +8149,7 @@ public class Onboarded extends CompanyEvent {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 21`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 23`] = `
 {
   "key": "org/acme/hr/ChangeOfAddress.java",
   "value": "// this code is generated and should not be modified
@@ -7830,6 +8161,7 @@ import org.acme.hr.base.SSN;
 import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -7863,6 +8195,38 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "value": "{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "org.acme.hr.base@1.0.0.Category": {
+      "title": "Category",
+      "description": "An instance of org.acme.hr.base@1.0.0.Category",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.base@1.0.0.Category",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.base@1\\\\.0\\\\.0\\\\.Category$",
+          "description": "The class identifier for org.acme.hr.base@1.0.0.Category"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
+    "org.acme.hr.base@1.0.0.GeneralCategory": {
+      "title": "GeneralCategory",
+      "description": "An instance of org.acme.hr.base@1.0.0.GeneralCategory",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.base@1.0.0.GeneralCategory",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.base@1\\\\.0\\\\.0\\\\.GeneralCategory$",
+          "description": "The class identifier for org.acme.hr.base@1.0.0.GeneralCategory"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
     "org.acme.hr.base@1.0.0.State": {
       "title": "State",
       "description": "An instance of org.acme.hr.base@1.0.0.State",
@@ -8274,7 +8638,16 @@ exports[`codegen #formats check we can convert all formats from namespace versio
         "height",
         "dob",
         "nextOfKin"
-      ]
+      ],
+      "$decorators": {
+        "category": [
+          {
+            "type": "Identifier",
+            "name": "GeneralCategory",
+            "array": false
+          }
+        ]
+      }
     },
     "org.acme.hr@1.0.0.Contractor": {
       "title": "Contractor",
@@ -8554,7 +8927,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "value": "# Namespace org.acme.hr.base@1.0.0
 
 ## Overview
-- 1 concepts
+- 3 concepts
 - 3 enumerations
 - 1 maps
 - 2 scalars
@@ -8562,7 +8935,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 - 0 participants
 - 0 transactions
 - 0 events
-- 7 total declarations
+- 9 total declarations
 
 ## Imports
 - concerto@1.0.0.Concept
@@ -8574,6 +8947,13 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 ## Diagram
 \`\`\`mermaid
 classDiagram
+class \`org.acme.hr.base@1.0.0.Category\`
+<< concept>> \`org.acme.hr.base@1.0.0.Category\`
+
+class \`org.acme.hr.base@1.0.0.GeneralCategory\`
+<< concept>> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+
+\`org.acme.hr.base@1.0.0.GeneralCategory\` --|> \`org.acme.hr.base@1.0.0.Category\`
 class \`org.acme.hr.base@1.0.0.State\` {
 << enumeration>>
    + MA
@@ -8632,6 +9012,7 @@ class \`org.acme.hr.base@1.0.0.Level\`
 - org.acme.hr.base@1.0.0.Time
 - org.acme.hr.base@1.0.0.EmployeeTShirtSizes
 - org.acme.hr.base@1.0.0.Level
+- org.acme.hr.base@1.0.0.GeneralCategory
 - concerto@1.0.0.Concept
 - concerto@1.0.0.Asset
 - concerto@1.0.0.Transaction
@@ -8799,6 +9180,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 {
   "key": "model.mmd",
   "value": "classDiagram
+class \`org.acme.hr.base@1.0.0.Category\`
+<< concept>> \`org.acme.hr.base@1.0.0.Category\`
+
+\`org.acme.hr.base@1.0.0.Category\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr.base@1.0.0.GeneralCategory\`
+<< concept>> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+
+\`org.acme.hr.base@1.0.0.GeneralCategory\` --|> \`org.acme.hr.base@1.0.0.Category\`
 class \`org.acme.hr.base@1.0.0.State\` {
 << enumeration>>
    + MA
@@ -9044,6 +9433,10 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 </edmx:Reference>
 <edmx:DataServices>
    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.acme.hr.base">
+      <ComplexType Name="Category" Abstract="true" BaseType="concerto.Concept">
+      </ComplexType>
+      <ComplexType Name="GeneralCategory" Abstract="true" BaseType="org.acme.hr.base.Category">
+      </ComplexType>
       <EnumType Name="State">
          <Member Name="MA">
          </Member>
@@ -9202,6 +9595,8 @@ exports[`codegen #formats check we can convert all formats from namespace versio
          </Property>
       </EntityType>
       <EntityType Name="Employee"  BaseType="org.acme.hr.Person">
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="[object Object]" />
          <Property Name="employeeId" Type="Edm.String"  >
          </Property>
          <Property Name="salary" Type="Edm.Int64"  >
@@ -9269,6 +9664,38 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   },
   "components": {
     "schemas": {
+      "org.acme.hr.base@1.0.0.Category": {
+        "title": "Category",
+        "description": "An instance of org.acme.hr.base@1.0.0.Category",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.base@1.0.0.Category",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.base@1\\\\.0\\\\.0\\\\.Category$",
+            "description": "The class identifier for org.acme.hr.base@1.0.0.Category"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "org.acme.hr.base@1.0.0.GeneralCategory": {
+        "title": "GeneralCategory",
+        "description": "An instance of org.acme.hr.base@1.0.0.GeneralCategory",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.base@1.0.0.GeneralCategory",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.base@1\\\\.0\\\\.0\\\\.GeneralCategory$",
+            "description": "The class identifier for org.acme.hr.base@1.0.0.GeneralCategory"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
       "org.acme.hr.base@1.0.0.State": {
         "title": "State",
         "description": "An instance of org.acme.hr.base@1.0.0.State",
@@ -9680,7 +10107,16 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "height",
           "dob",
           "nextOfKin"
-        ]
+        ],
+        "$decorators": {
+          "category": [
+            {
+              "type": "Identifier",
+              "name": "GeneralCategory",
+              "array": false
+            }
+          ]
+        }
       },
       "org.acme.hr@1.0.0.Contractor": {
         "title": "Contractor",
@@ -10210,6 +10646,12 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 title
 Model
 endtitle
+class org.acme.hr.base_1_0_0.Category {
+}
+org.acme.hr.base_1_0_0.Category --|> concerto_1_0_0.Concept
+class org.acme.hr.base_1_0_0.GeneralCategory {
+}
+org.acme.hr.base_1_0_0.GeneralCategory --|> org.acme.hr.base_1_0_0.Category
 class org.acme.hr.base_1_0_0.State << (E,grey) >> {
    + MA
    + NY
@@ -10740,6 +11182,22 @@ use crate::concerto_1_0_0::*;
 use std::collections::HashMap;
 use crate::utils::*;
    
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GeneralCategory {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum State {
    #[allow(non_camel_case_types)]
@@ -11333,6 +11791,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	ICategory,
 	State,
 	TShirtSizeType,
 	IAddress,
@@ -11369,7 +11828,8 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IAddress | 
+export type ConceptUnion = ICategory | 
+IAddress | 
 ICompany;
 
 export interface IAsset extends IConcept {
@@ -11438,9 +11898,19 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: org.acme.hr.base@1.0.0
 
 // imports
+
+// Warning: Beware of circular dependencies when modifying these imports
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
+export interface ICategory extends IConcept {
+}
+
+export type CategoryUnion = IGeneralCategory;
+
+export interface IGeneralCategory extends ICategory {
+}
+
 export enum State {
    MA = 'MA',
    NY = 'NY',
@@ -11600,6 +12070,8 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 locale: en
 namespace: org.acme.hr.base@1.0.0
 declarations:
+  - Category: Category
+  - GeneralCategory: General Category
   - State: State
     properties:
       - MA: MA of the State
@@ -11849,6 +12321,24 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 xmlns:concerto="concerto"
 >
 <xs:import namespace="concerto" schemaLocation="concerto@1.0.0.xsd"/>
+<xs:complexType name="Category">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Category" type="org.acme.hr.base:Category"/>
+<xs:complexType name="GeneralCategory">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr.base:Category">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="GeneralCategory" type="org.acme.hr.base:GeneralCategory"/>
 <xs:simpleType name="State">
    <xs:restriction base="xs:string">
       <xs:enumeration value="MA"/>

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -703,8 +703,9 @@ type ChangeOfAddress struct {
 exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'graphql' 1`] = `
 {
   "key": "model.gql",
-  "value": "directive @resource on OBJECT | FIELD_DEFINITION
-directive @category on OBJECT | FIELD_DEFINITION
+  "value": "directive @category on OBJECT | FIELD_DEFINITION
+directive @resource on OBJECT | FIELD_DEFINITION
+directive @test on OBJECT | FIELD_DEFINITION
 scalar DateTime
 # namespace org.acme.hr.base
 type Category {
@@ -774,7 +775,7 @@ type Company {
    employeeProfiles: EmployeeProfiles
    employeeSocialSecurityNumbers: EmployeeSocialSecurityNumbers
 }
-enum Department {
+enum Department @category {
    Sales
    Marketing
    Finance
@@ -786,7 +787,7 @@ type Equipment @resource {
    serialNumber: String!
    _identifier: String!
 }
-enum LaptopMake {
+enum LaptopMake @test {
    Apple
    Microsoft
 }
@@ -1935,7 +1936,16 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
         "HR",
         "Engineering",
         "Design"
-      ]
+      ],
+      "$decorators": {
+        "category": [
+          {
+            "type": "Identifier",
+            "name": "GeneralCategory",
+            "array": false
+          }
+        ]
+      }
     },
     "org.acme.hr.Equipment": {
       "title": "Equipment",
@@ -1967,7 +1977,12 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
       "enum": [
         "Apple",
         "Microsoft"
-      ]
+      ],
+      "$decorators": {
+        "test": [
+          "one"
+        ]
+      }
     },
     "org.acme.hr.Laptop": {
       "title": "Laptop",
@@ -3059,6 +3074,8 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
       </ComplexType>
       <EnumType Name="Department">
          <Member Name="Sales">
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="GeneralCategory" />
          </Member>
          <Member Name="Marketing">
          </Member>
@@ -3111,7 +3128,7 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
       </EntityType>
       <EntityType Name="Employee"  BaseType="org.acme.hr.Person">
             <Annotation Term="category" Bool="true"/>
-            <Annotation Term="category0" String="[object Object]" />
+            <Annotation Term="category0" String="GeneralCategory" />
          <Property Name="employeeId" Type="Edm.String"  >
          </Property>
          <Property Name="salary" Type="Edm.Int64"  >
@@ -3134,7 +3151,7 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
          </Property>
          <NavigationProperty Name="manager" Type="org.acme.hr.Manager" Nullable="true">
             <Annotation Term="level" Bool="true"/>
-            <Annotation Term="level0" String="[object Object]" />
+            <Annotation Term="level0" String="Level" />
          </NavigationProperty>
       </EntityType>
       <EntityType Name="Manager"  BaseType="org.acme.hr.Employee">
@@ -3388,7 +3405,16 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
           "HR",
           "Engineering",
           "Design"
-        ]
+        ],
+        "$decorators": {
+          "category": [
+            {
+              "type": "Identifier",
+              "name": "GeneralCategory",
+              "array": false
+            }
+          ]
+        }
       },
       "org.acme.hr.Equipment": {
         "title": "Equipment",
@@ -3420,7 +3446,12 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
         "enum": [
           "Apple",
           "Microsoft"
-        ]
+        ],
+        "$decorators": {
+          "test": [
+            "one"
+          ]
+        }
       },
       "org.acme.hr.Laptop": {
         "title": "Laptop",
@@ -7172,8 +7203,9 @@ type ChangeOfAddress struct {
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'graphql' 1`] = `
 {
   "key": "model.gql",
-  "value": "directive @resource on OBJECT | FIELD_DEFINITION
-directive @category on OBJECT | FIELD_DEFINITION
+  "value": "directive @category on OBJECT | FIELD_DEFINITION
+directive @resource on OBJECT | FIELD_DEFINITION
+directive @test on OBJECT | FIELD_DEFINITION
 scalar DateTime
 # namespace org.acme.hr.base@1.0.0
 type Category {
@@ -7243,7 +7275,7 @@ type Company {
    employeeProfiles: EmployeeProfiles
    employeeSocialSecurityNumbers: EmployeeSocialSecurityNumbers
 }
-enum Department {
+enum Department @category {
    Sales
    Marketing
    Finance
@@ -7255,7 +7287,7 @@ type Equipment @resource {
    serialNumber: String!
    _identifier: String!
 }
-enum LaptopMake {
+enum LaptopMake @test {
    Apple
    Microsoft
 }
@@ -8404,7 +8436,16 @@ exports[`codegen #formats check we can convert all formats from namespace versio
         "HR",
         "Engineering",
         "Design"
-      ]
+      ],
+      "$decorators": {
+        "category": [
+          {
+            "type": "Identifier",
+            "name": "GeneralCategory",
+            "array": false
+          }
+        ]
+      }
     },
     "org.acme.hr@1.0.0.Equipment": {
       "title": "Equipment",
@@ -8436,7 +8477,12 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       "enum": [
         "Apple",
         "Microsoft"
-      ]
+      ],
+      "$decorators": {
+        "test": [
+          "one"
+        ]
+      }
     },
     "org.acme.hr@1.0.0.Laptop": {
       "title": "Laptop",
@@ -9544,6 +9590,8 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       </ComplexType>
       <EnumType Name="Department">
          <Member Name="Sales">
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="GeneralCategory" />
          </Member>
          <Member Name="Marketing">
          </Member>
@@ -9596,7 +9644,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       </EntityType>
       <EntityType Name="Employee"  BaseType="org.acme.hr.Person">
             <Annotation Term="category" Bool="true"/>
-            <Annotation Term="category0" String="[object Object]" />
+            <Annotation Term="category0" String="GeneralCategory" />
          <Property Name="employeeId" Type="Edm.String"  >
          </Property>
          <Property Name="salary" Type="Edm.Int64"  >
@@ -9619,7 +9667,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
          </Property>
          <NavigationProperty Name="manager" Type="org.acme.hr.Manager" Nullable="true">
             <Annotation Term="level" Bool="true"/>
-            <Annotation Term="level0" String="[object Object]" />
+            <Annotation Term="level0" String="Level" />
          </NavigationProperty>
       </EntityType>
       <EntityType Name="Manager"  BaseType="org.acme.hr.Employee">
@@ -9873,7 +9921,16 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "HR",
           "Engineering",
           "Design"
-        ]
+        ],
+        "$decorators": {
+          "category": [
+            {
+              "type": "Identifier",
+              "name": "GeneralCategory",
+              "array": false
+            }
+          ]
+        }
       },
       "org.acme.hr@1.0.0.Equipment": {
         "title": "Equipment",
@@ -9905,7 +9962,12 @@ exports[`codegen #formats check we can convert all formats from namespace versio
         "enum": [
           "Apple",
           "Microsoft"
-        ]
+        ],
+        "$decorators": {
+          "test": [
+            "one"
+          ]
+        }
       },
       "org.acme.hr@1.0.0.Laptop": {
         "title": "Laptop",

--- a/test/codegen/codegen.js
+++ b/test/codegen/codegen.js
@@ -45,7 +45,8 @@ describe('codegen', function () {
         versionedModelManager.addCTOModel(cto, 'hr.cto');
 
         const unversionedBaseCto = base_cto.replace('namespace org.acme.hr.base@1.0.0', 'namespace org.acme.hr.base');
-        const unversionedCto = cto.replace('namespace org.acme.hr@1.0.0', 'namespace org.acme.hr').replace('import org.acme.hr.base@1.0.0', 'import org.acme.hr.base');
+        const unversionedCto = cto.replace('namespace org.acme.hr@1.0.0', 'namespace org.acme.hr').
+            replace('import org.acme.hr.base@1.0.0', 'import org.acme.hr.base');
         unversionedModelManager.addCTOModel(unversionedBaseCto, 'hr_base.cto');
         unversionedModelManager.addCTOModel(unversionedCto, 'hr.cto');
     });

--- a/test/codegen/fromcto/data/model/hr.cto
+++ b/test/codegen/fromcto/data/model/hr.cto
@@ -1,6 +1,6 @@
 namespace org.acme.hr@1.0.0
 
-import org.acme.hr.base@1.0.0.{Address, State, SSN, Time, EmployeeTShirtSizes, Level}
+import org.acme.hr.base@1.0.0.{Address, State, SSN, Time, EmployeeTShirtSizes, Level, GeneralCategory}
 
 map CompanyProperties {
     o String
@@ -79,6 +79,7 @@ abstract participant Person identified by email {
     o NextOfKin nextOfKin
 }
 
+@category(GeneralCategory)
 participant Employee extends Person {
     o String employeeId
     o Long salary

--- a/test/codegen/fromcto/data/model/hr.cto
+++ b/test/codegen/fromcto/data/model/hr.cto
@@ -1,3 +1,4 @@
+@category(GeneralCategory)
 namespace org.acme.hr@1.0.0
 
 import org.acme.hr.base@1.0.0.{Address, State, SSN, Time, EmployeeTShirtSizes, Level, GeneralCategory}
@@ -43,7 +44,9 @@ concept Company {
     o EmployeeSocialSecurityNumbers employeeSocialSecurityNumbers optional
 }
 
+@category(GeneralCategory)
 enum Department {
+    @category(GeneralCategory)
     o Sales
     o Marketing
     o Finance
@@ -57,6 +60,7 @@ abstract asset Equipment identified by serialNumber {
     o String serialNumber
 }
 
+@test("one")
 enum LaptopMake {
     o Apple
     o Microsoft
@@ -113,5 +117,6 @@ transaction ChangeOfAddress {
     o Address newAddress
 }
 
+@category(GeneralCategory)
 scalar KinName extends String
 scalar KinTelephone extends String

--- a/test/codegen/fromcto/data/model/hr_base.cto
+++ b/test/codegen/fromcto/data/model/hr_base.cto
@@ -1,5 +1,8 @@
 namespace org.acme.hr.base@1.0.0
 
+abstract concept Category {}
+abstract concept GeneralCategory extends Category {}
+
 enum State {
     o MA
     o NY

--- a/test/codegen/fromcto/data/model/hr_base.cto
+++ b/test/codegen/fromcto/data/model/hr_base.cto
@@ -1,3 +1,4 @@
+@description("hr base namespace")
 namespace org.acme.hr.base@1.0.0
 
 abstract concept Category {}

--- a/test/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/test/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -544,6 +544,7 @@ describe('PlantUMLVisitor', function () {
             mockField.isField.returns(true);
             mockField.getType.returns('string');
             mockField.getName.returns('Bob');
+            mockField.getDecorators.returns([]);
             mockField.getParent.returns({
                 getFullyQualifiedName: () => { return 'org.acme.Human'; },
             });
@@ -563,6 +564,7 @@ describe('PlantUMLVisitor', function () {
             mockField.getType.returns('string');
             mockField.getName.returns('Bob');
             mockField.isArray.returns(true);
+            mockField.getDecorators.returns([]);
             mockField.getParent.returns({
                 getFullyQualifiedName: () => { return 'org.acme.Human'; },
             });
@@ -582,6 +584,7 @@ describe('PlantUMLVisitor', function () {
             let mockEnumValueDecl = sinon.createStubInstance(EnumValueDeclaration);
             mockEnumValueDecl.isEnumValue.returns(true);
             mockEnumValueDecl.getName.returns('Bob');
+            mockEnumValueDecl.getDecorators.returns([]);
 
             plantUMLvisitor.visitEnumValueDeclaration(mockEnumValueDecl, param);
 

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -47,6 +47,9 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
    \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Department.Sales\`
+   \`org.acme.hr@1.0.0.Department.Sales\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`concerto@1.0.0.Asset\`
    \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
@@ -88,7 +91,10 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0\`
+   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 
@@ -139,6 +145,9 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
    \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Department.Sales\`
+   \`org.acme.hr@1.0.0.Department.Sales\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
    \`org.acme.hr@1.0.0.LaptopMake\`
@@ -176,7 +185,10 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0\`
+   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 
@@ -221,6 +233,7 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
    \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`concerto@1.0.0.Asset\`
    \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
@@ -254,6 +267,7 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
 "
 `;

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -1,0 +1,259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graph #visitor should visit a model manager 1`] = `
+"flowchart LR
+   \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Equipment\`
+   \`concerto@1.0.0.Asset\`
+   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Laptop\`
+   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`concerto@1.0.0.Participant\`
+   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Contractor\`
+   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Contractor.manager\`
+   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`concerto@1.0.0.Event\`
+   \`concerto@1.0.0.Event\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\`
+   \`org.acme.hr@1.0.0.Onboarded\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`concerto@1.0.0.Transaction\`
+   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinTelephone\`
+"
+`;
+
+exports[`graph #visitor should visit a model manager and create a dependency graph 1`] = `
+"flowchart LR
+   \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` --> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
+   \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Laptop\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Contractor\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Contractor.manager\`
+   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
+   \`org.acme.hr@1.0.0.Onboarded\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinTelephone\`
+"
+`;
+
+exports[`graph #visitor should visit find a connected subgraph 1`] = `
+"flowchart LR
+   \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.NextOfKin\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Equipment\`
+   \`concerto@1.0.0.Asset\`
+   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Laptop\`
+   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`concerto@1.0.0.Participant\`
+   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Contractor\`
+   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`concerto@1.0.0.Transaction\`
+   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinTelephone\`
+"
+`;

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -62,90 +62,7 @@ describe('graph', function() {
             writer.openFile('graph.mmd');
             graph.print(writer);
             writer.closeFile();
-            expect(writer.data.get('graph.mmd')).toEqual(`flowchart LR
-   \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.Time\`
-   \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.NextOfKin\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Equipment\`
-   \`concerto@1.0.0.Asset\`
-   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
-   \`concerto@1.0.0.Participant\`
-   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`concerto@1.0.0.Event\`
-   \`concerto@1.0.0.Event\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`org.acme.hr@1.0.0.Onboarded\`
-   \`org.acme.hr@1.0.0.Onboarded\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`concerto@1.0.0.Transaction\`
-   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinTelephone\`
-`);
+            expect(writer.data.get('graph.mmd')).toMatchSnapshot();
         });
 
         it('should visit find a connected subgraph', function() {
@@ -173,81 +90,12 @@ describe('graph', function() {
             expect(filteredModelManager.getModelFiles()).toHaveLength(2);
             expect(
                 filteredModelManager.getModelFiles()[0].getAllDeclarations()
-            ).toHaveLength(5);
+            ).toHaveLength(7);
 
             writer.openFile('graph.mmd');
             connectedGraph.print(writer);
             writer.closeFile();
-            expect(writer.data.get('graph.mmd')).toEqual(`flowchart LR
-   \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.NextOfKin\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Equipment\`
-   \`concerto@1.0.0.Asset\`
-   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
-   \`concerto@1.0.0.Participant\`
-   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`concerto@1.0.0.Transaction\`
-   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinTelephone\`
-`);
+            expect(writer.data.get('graph.mmd')).toMatchSnapshot();
         });
 
         it('should visit a model manager and create a dependency graph', function() {
@@ -264,86 +112,7 @@ describe('graph', function() {
             writer.openFile('graph.mmd');
             graph.print(writer);
             writer.closeFile();
-            expect(writer.data.get('graph.mmd')).toEqual(`flowchart LR
-   \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.Time\`
-   \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.NextOfKin\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
-   \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
-   \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
-   \`org.acme.hr@1.0.0.Onboarded\`
-   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinTelephone\`
-`);
+            expect(writer.data.get('graph.mmd')).toMatchSnapshot();
         });
     });
 });


### PR DESCRIPTION
Fixes a crash with the logic to add types referenced in decorators to the graph. Updates tests to prove it works.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
