### PR TITLE
fix(graph): add edge to map relationship between declarations and decorators on fields

### DIFF
--- a/lib/common/basevisitor.js
+++ b/lib/common/basevisitor.js
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+/* istanbul ignore next */
+if (global === undefined) {
+    const { ModelManager, ModelFile, ClassDeclaration, ScalarDeclaration, Field, EnumValueDeclaration, RelationshipDeclaration, Decorator} = require('@accordproject/concerto-core');
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * Convert the contents of a ModelManager a diagram format (such as PlantUML or Mermaid)
+ * Set a fileWriter property (instance of FileWriter) on the parameters
+ * object to control where the generated code is written to disk.
+ *
+ * @protected
+ * @class
+ */
+class BaseVisitor {
+
+    /**
+     * Visitor design pattern
+     * @param {Object} thing - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @protected
+     */
+    visit(thing, parameters) {
+        if (thing.isModelManager?.()) {
+            return this.visitModelManager(thing, parameters);
+        } else if (thing.isModelFile?.()) {
+            return this.visitModelFile(thing, parameters);
+        } else if (thing.isParticipant?.()) {
+            return this.visitParticipantDeclaration(thing, parameters);
+        } else if (thing.isTransaction?.()) {
+            return this.visitTransactionDeclaration(thing, parameters);
+        } else if (thing.isEvent?.()) {
+            return this.visitEventDeclaration(thing, parameters);
+        } else if (thing.isAsset?.()) {
+            return this.visitAssetDeclaration(thing, parameters);
+        } else if (thing.isMapDeclaration?.()) {
+            return this.visitMapDeclaration(thing, parameters);
+        } else if (thing.isEnum?.()) {
+            return this.visitEnumDeclaration(thing, parameters);
+        } else if (thing.isClassDeclaration?.()) {
+            return this.visitClassDeclaration(thing, parameters);
+        } else if (thing.isTypeScalar?.()) {
+            return this.visitScalarField(thing, parameters);
+        } else if (thing.isField?.()) {
+            return this.visitField(thing, parameters);
+        } else if (thing.isRelationship?.()) {
+            return this.visitRelationship(thing, parameters);
+        } else if (thing.isEnumValue?.()) {
+            return this.visitEnumValueDeclaration(thing, parameters);
+        } else if (thing.isScalarDeclaration?.()) {
+            return this.visitScalarDeclaration(thing, parameters);
+        } else if (thing.isDecorator?.()) {
+            return this.visitDecorator(thing, parameters);
+        } else {
+            throw new Error('Unrecognised ' + JSON.stringify(thing) );
+        }
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ModelManager} modelManager - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitModelManager(modelManager, parameters) {
+        modelManager.getModelFiles().forEach((decl) => {
+            decl.accept(this, parameters);
+        });
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ModelFile} modelFile - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitModelFile(modelFile, parameters) {
+        modelFile.getAllDeclarations().forEach((decl) => {
+            decl.accept(this, parameters);
+        });
+        modelFile.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitAssetDeclaration(classDeclaration, parameters) {
+        this.visitClassDeclaration(classDeclaration, parameters, 'asset');
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitEnumDeclaration(classDeclaration, parameters) {
+        this.visitClassDeclaration(classDeclaration, parameters, 'enumeration');
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitEventDeclaration(classDeclaration, parameters) {
+        this.visitClassDeclaration(classDeclaration, parameters, 'event');
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitParticipantDeclaration(classDeclaration, parameters) {
+        this.visitClassDeclaration(classDeclaration, parameters, 'participant');
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitTransactionDeclaration(classDeclaration, parameters) {
+        this.visitClassDeclaration(classDeclaration, parameters, 'transaction');
+    }
+
+
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @param {string} type  - the type of the declaration
+     * @protected
+     */
+    visitClassDeclaration(classDeclaration, parameters, type = 'concept') {
+        classDeclaration.getOwnProperties().forEach((property) => {
+            property.accept(this, parameters);
+        });
+        classDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitScalarDeclaration(scalarDeclaration, parameters) {
+        scalarDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        return;
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitMapDeclaration(mapDeclaration, parameters) {
+        mapDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        mapDeclaration.getKey().getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        mapDeclaration.getValue().getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        return;
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitScalarField(field, parameters) {
+        this.visitField(field.getScalarField(), parameters);
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {RelationshipDeclaration} relationship - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitRelationship(relationship, parameters) {
+        this.visitField(relationship, parameters);
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitField(field, parameters) {
+        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitEnumValueDeclaration(enumValueDeclaration, parameters) {
+        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {Decorator} decorator - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    visitDecorator(decorator, parameters) {
+        return;
+    }
+}
+
+module.exports = BaseVisitor;

--- a/lib/common/basevisitor.js
+++ b/lib/common/basevisitor.js
@@ -23,9 +23,7 @@ if (global === undefined) {
 /* eslint-enable no-unused-vars */
 
 /**
- * Convert the contents of a ModelManager a diagram format (such as PlantUML or Mermaid)
- * Set a fileWriter property (instance of FileWriter) on the parameters
- * object to control where the generated code is written to disk.
+ * Visitor class that traverses various model elements
  *
  * @protected
  * @class

--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const ModelUtil = require('@accordproject/concerto-core').ModelUtil;
+const BaseVisitor = require('./basevisitor');
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -32,184 +33,8 @@ if (global === undefined) {
  * @protected
  * @class
  */
-class DiagramVisitor {
+class DiagramVisitor extends BaseVisitor {
 
-    /**
-     * Visitor design pattern
-     * @param {Object} thing - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @return {Object} the result of visiting or null
-     * @protected
-     */
-    visit(thing, parameters) {
-        if (thing.isModelManager?.()) {
-            return this.visitModelManager(thing, parameters);
-        } else if (thing.isModelFile?.()) {
-            return this.visitModelFile(thing, parameters);
-        } else if (thing.isParticipant?.()) {
-            return this.visitParticipantDeclaration(thing, parameters);
-        } else if (thing.isTransaction?.()) {
-            return this.visitTransactionDeclaration(thing, parameters);
-        } else if (thing.isEvent?.()) {
-            return this.visitEventDeclaration(thing, parameters);
-        } else if (thing.isAsset?.()) {
-            return this.visitAssetDeclaration(thing, parameters);
-        } else if (thing.isMapDeclaration?.()) {
-            return this.visitMapDeclaration(thing, parameters);
-        } else if (thing.isEnum?.()) {
-            return this.visitEnumDeclaration(thing, parameters);
-        } else if (thing.isClassDeclaration?.()) {
-            return this.visitClassDeclaration(thing, parameters);
-        } else if (thing.isTypeScalar?.()) {
-            return this.visitScalarField(thing, parameters);
-        } else if (thing.isField?.()) {
-            return this.visitField(thing, parameters);
-        } else if (thing.isRelationship?.()) {
-            return this.visitRelationship(thing, parameters);
-        } else if (thing.isEnumValue?.()) {
-            return this.visitEnumValueDeclaration(thing, parameters);
-        } else if (thing.isScalarDeclaration?.()) {
-            return this.visitScalarDeclaration(thing, parameters);
-        } else if (thing.isDecorator?.()) {
-            return this.visitDecorator(thing, parameters);
-        } else {
-            throw new Error('Unrecognised ' + JSON.stringify(thing) );
-        }
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ModelManager} modelManager - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitModelManager(modelManager, parameters) {
-        modelManager.getModelFiles().forEach((decl) => {
-            decl.accept(this, parameters);
-        });
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ModelFile} modelFile - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitModelFile(modelFile, parameters) {
-        modelFile.getAllDeclarations().forEach((decl) => {
-            decl.accept(this, parameters);
-        });
-        modelFile.getDecorators().forEach(decorator => decorator.accept(this, parameters));
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitAssetDeclaration(classDeclaration, parameters) {
-        this.visitClassDeclaration(classDeclaration, parameters, 'asset');
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitEnumDeclaration(classDeclaration, parameters) {
-        this.visitClassDeclaration(classDeclaration, parameters, 'enumeration');
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitEventDeclaration(classDeclaration, parameters) {
-        this.visitClassDeclaration(classDeclaration, parameters, 'event');
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitParticipantDeclaration(classDeclaration, parameters) {
-        this.visitClassDeclaration(classDeclaration, parameters, 'participant');
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitTransactionDeclaration(classDeclaration, parameters) {
-        this.visitClassDeclaration(classDeclaration, parameters, 'transaction');
-    }
-
-
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @param {string} type  - the type of the declaration
-     * @protected
-     */
-    visitClassDeclaration(classDeclaration, parameters, type = 'concept') {
-        classDeclaration.getOwnProperties().forEach((property) => {
-            property.accept(this, parameters);
-        });
-        classDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitScalarDeclaration(scalarDeclaration, parameters) {
-        scalarDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
-        return;
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {MapDeclaration} mapDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitMapDeclaration(mapDeclaration, parameters) {
-        mapDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
-        mapDeclaration.getKey().getDecorators().forEach(decorator => decorator.accept(this, parameters));
-        mapDeclaration.getValue().getDecorators().forEach(decorator => decorator.accept(this, parameters));
-        return;
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {Field} field - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitScalarField(field, parameters) {
-        this.visitField(field.getScalarField(), parameters);
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {RelationshipDeclaration} relationship - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitRelationship(relationship, parameters) {
-        this.visitField(relationship, parameters);
-    }
 
     /**
      * Visitor design pattern
@@ -223,7 +48,7 @@ class DiagramVisitor {
         if(field.isArray()) {
             array = '[]';
         }
-        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitField(field, parameters);
         if(parameters.fileWriter) {
             parameters.fileWriter.writeLine(1, '+ ' + field.getType() + array + ' ' + field.getName());
         }
@@ -236,20 +61,10 @@ class DiagramVisitor {
      * @protected
      */
     visitEnumValueDeclaration(enumValueDeclaration, parameters) {
-        enumValueDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        super.visitEnumValueDeclaration(enumValueDeclaration, parameters);
         if(parameters.fileWriter) {
             parameters.fileWriter.writeLine(1, '+ ' + enumValueDeclaration.getName());
         }
-    }
-
-    /**
-     * Visitor design pattern
-     * @param {Decorator} decorator - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    visitDecorator(decorator, parameters) {
-        return;
     }
 
     /**

--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -186,6 +186,8 @@ class DiagramVisitor {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         mapDeclaration.getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        mapDeclaration.getKey().getDecorators().forEach(decorator => decorator.accept(this, parameters));
+        mapDeclaration.getValue().getDecorators().forEach(decorator => decorator.accept(this, parameters));
         return;
     }
 

--- a/lib/common/diagramvisitor.js
+++ b/lib/common/diagramvisitor.js
@@ -21,7 +21,7 @@ const BaseVisitor = require('./basevisitor');
 /* eslint-disable no-unused-vars */
 /* istanbul ignore next */
 if (global === undefined) {
-    const { ModelManager, ModelFile, ClassDeclaration, ScalarDeclaration, Field, EnumValueDeclaration, RelationshipDeclaration, Decorator} = require('@accordproject/concerto-core');
+    const { ClassDeclaration, Field, EnumValueDeclaration} = require('@accordproject/concerto-core');
 }
 /* eslint-enable no-unused-vars */
 
@@ -34,7 +34,6 @@ if (global === undefined) {
  * @class
  */
 class DiagramVisitor extends BaseVisitor {
-
 
     /**
      * Visitor design pattern

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -182,10 +182,6 @@ class ConcertoGraphVisitor extends DiagramVisitor {
 
         if (classDeclaration.getSuperType()){
             parameters.graph.addEdge(classDeclaration.getFullyQualifiedName(), classDeclaration.getSuperType());
-            // this "if" block adds the types that extend the Super type
-            if(!parameters.createDependencyGraph && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
-                parameters.graph.addVertex(classDeclaration.getSuperType());
-            }
         }
         super.visitClassDeclaration(classDeclaration, parameters);
     }

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -181,6 +181,12 @@ class ConcertoGraphVisitor extends BaseVisitor {
 
         if (classDeclaration.getSuperType()){
             parameters.graph.addEdge(classDeclaration.getFullyQualifiedName(), classDeclaration.getSuperType());
+
+            // Adds a reverse edge to create a cyclic dependency between a class declaration and its supertype.
+            if(!parameters.createDependencyGraph && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
+                parameters.graph.addVertex(classDeclaration.getSuperType());
+                parameters.graph.addEdge(classDeclaration.getSuperType(), classDeclaration.getFullyQualifiedName());
+            }
         }
         super.visitClassDeclaration(classDeclaration, parameters);
     }

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -15,8 +15,7 @@
 'use strict';
 
 const { ModelUtil } = require('@accordproject/concerto-core');
-
-const DiagramVisitor = require('./diagramvisitor');
+const BaseVisitor = require('./basevisitor');
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -170,7 +169,7 @@ class DirectedGraph {
  * @class
  * @memberof module:concerto-util
  */
-class ConcertoGraphVisitor extends DiagramVisitor {
+class ConcertoGraphVisitor extends BaseVisitor {
     /**
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -219,8 +219,8 @@ class ConcertoGraphVisitor extends DiagramVisitor {
             if(argument && argument.name) {
                 const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
                 if (fqn) {
-                    parameters.graph.addVertex(fqn);
-                    (parent === modelFile) ? parameters.graph.addEdge(parent.getNamespace(), fqn) : parameters.graph.addEdge(parent.getFullyQualifiedName(), fqn);
+                    const m = modelFile.getModelManager().getType(fqn);
+                    parameters.graph.addEdge(parameters.stack.slice(-1), m.getFullyQualifiedName());
                 }
             }
         });

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -14,7 +14,7 @@
  */
 'use strict';
 
-const { ModelUtil } = require('@accordproject/concerto-core');
+const { ModelUtil, Property } = require('@accordproject/concerto-core');
 
 const DiagramVisitor = require('./diagramvisitor');
 
@@ -219,10 +219,13 @@ class ConcertoGraphVisitor extends DiagramVisitor {
             if(argument && argument.name) {
                 const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
                 if (fqn) {
-                    const m = modelFile.getModelManager().getType(fqn);
-                    (parent === modelFile)
-                        ? parameters.graph.addEdge(parent.getNamespace(), m.getFullyQualifiedName())
-                        : parameters.graph.addEdge(parameters.stack.slice(-1), m.getFullyQualifiedName());
+                    const type = modelFile.getModelManager().getType(fqn);
+                    const parentFqn = parent === modelFile ? parent.getNamespace() : parent.getFullyQualifiedName();
+                    if (parent instanceof Property) {
+                        parameters.graph.addEdge(parameters.stack.slice(-1), type.getFullyQualifiedName());
+                    } else {
+                        parameters.graph.addEdge(parentFqn, type.getFullyQualifiedName());
+                    }
                 }
             }
         });

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -215,21 +215,27 @@ class ConcertoGraphVisitor extends DiagramVisitor {
         super.visitDecorator(decorator, parameters);
         const parent = decorator.getParent();
         const modelFile = parent.getModelFile();
-        decorator.getArguments()?.forEach(argument => {
-            if(argument && argument.name) {
-                const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
-                if (fqn) {
-                    parameters.graph.addVertex(fqn);
-                    const type = modelFile.getModelManager().getType(fqn);
-                    let parentFqn = parent === modelFile ? parent.getNamespace() : parent.getFullyQualifiedName?.();
-                    const isParentPropertyType = parent.isField?.() || parent.isRelationship?.() || parent.isEnumValue?.() || parent.isKey?.() || parent.isValue?.();
-                    if (isParentPropertyType) {
-                        parentFqn = parent.getParent().getFullyQualifiedName();
-                    }
-                    parameters.graph.addEdge(parentFqn, type.getFullyQualifiedName());
-                }
-            }
-        });
+        // Process the decorator name and arguments in a unified way
+        const namesToProcess = [
+            decorator.name,
+            ...(decorator.getArguments()?.map(arg => arg?.name).filter(Boolean) || [])
+        ];
+        namesToProcess.forEach(name => this.addEdgeForDecorator(name, parent, modelFile, parameters));
+    }
+
+    addEdgeForDecorator(name, parent, modelFile, parameters) {
+        const fqn = modelFile.getFullyQualifiedTypeName(name);
+        if (fqn) {
+            parameters.graph.addVertex(fqn);
+
+            // Determine parent FQN based on property type
+            const type = modelFile.getModelManager().getType(fqn);
+            const isParentPropertyType = parent.isField?.() || parent.isRelationship?.() || parent.isEnumValue?.() || parent.isKey?.() || parent.isValue?.();
+            let parentFqn = isParentPropertyType ? parent.getParent().getFullyQualifiedName() : parent.getFullyQualifiedName?.();
+            parentFqn ??= parent.getNamespace(); //parent is a modelfile
+
+            parameters.graph.addEdge(parentFqn, type.getFullyQualifiedName());
+        }
     }
 
     /**

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -220,7 +220,9 @@ class ConcertoGraphVisitor extends DiagramVisitor {
                 const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
                 if (fqn) {
                     const m = modelFile.getModelManager().getType(fqn);
-                    parameters.graph.addEdge(parameters.stack.slice(-1), m.getFullyQualifiedName());
+                    (parent === modelFile)
+                        ? parameters.graph.addEdge(parent.getNamespace(), m.getFullyQualifiedName())
+                        : parameters.graph.addEdge(parameters.stack.slice(-1), m.getFullyQualifiedName());
                 }
             }
         });

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -174,6 +174,8 @@ class ConcertoGraphVisitor extends BaseVisitor {
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited
      * @param {Object} parameters  - the parameter
+     * @property {boolean} parameters.includeDerivedTypes - If this option is enabled, edges will be created from super types to their derived types.
+     * This guarantees that if type X exists in the model manager, all types that inherit from X will be represented in the graph.
      * @protected
      */
     visitClassDeclaration(classDeclaration, parameters) {
@@ -183,7 +185,7 @@ class ConcertoGraphVisitor extends BaseVisitor {
             parameters.graph.addEdge(classDeclaration.getFullyQualifiedName(), classDeclaration.getSuperType());
 
             // Adds a reverse edge to create a cyclic dependency between a class declaration and its supertype.
-            if(!parameters.createDependencyGraph && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
+            if(parameters.includeDerivedTypes && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
                 parameters.graph.addVertex(classDeclaration.getSuperType());
                 parameters.graph.addEdge(classDeclaration.getSuperType(), classDeclaration.getFullyQualifiedName());
             }

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -14,7 +14,7 @@
  */
 'use strict';
 
-const { ModelUtil, Property } = require('@accordproject/concerto-core');
+const { ModelUtil } = require('@accordproject/concerto-core');
 
 const DiagramVisitor = require('./diagramvisitor');
 
@@ -219,13 +219,14 @@ class ConcertoGraphVisitor extends DiagramVisitor {
             if(argument && argument.name) {
                 const fqn = modelFile.getFullyQualifiedTypeName(argument.name);
                 if (fqn) {
+                    parameters.graph.addVertex(fqn);
                     const type = modelFile.getModelManager().getType(fqn);
-                    const parentFqn = parent === modelFile ? parent.getNamespace() : parent.getFullyQualifiedName();
-                    if (parent instanceof Property) {
-                        parameters.graph.addEdge(parameters.stack.slice(-1), type.getFullyQualifiedName());
-                    } else {
-                        parameters.graph.addEdge(parentFqn, type.getFullyQualifiedName());
+                    let parentFqn = parent === modelFile ? parent.getNamespace() : parent.getFullyQualifiedName?.();
+                    const isParentPropertyType = parent.isField?.() || parent.isRelationship?.() || parent.isEnumValue?.() || parent.isKey?.() || parent.isValue?.();
+                    if (isParentPropertyType) {
+                        parentFqn = parent.getParent().getFullyQualifiedName();
                     }
+                    parameters.graph.addEdge(parentFqn, type.getFullyQualifiedName());
                 }
             }
         });

--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -178,8 +178,6 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      * @protected
      */
     visitClassDeclaration(classDeclaration, parameters) {
-        parameters.stack ??= [];
-        parameters.stack.push(classDeclaration.getFullyQualifiedName());
         parameters.graph.addVertex(classDeclaration.getFullyQualifiedName());
 
         if (classDeclaration.getSuperType()){
@@ -187,11 +185,9 @@ class ConcertoGraphVisitor extends DiagramVisitor {
             // this "if" block adds the types that extend the Super type
             if(!parameters.createDependencyGraph && classDeclaration.getSuperType() !== 'concerto@1.0.0.Concept') {
                 parameters.graph.addVertex(classDeclaration.getSuperType());
-                parameters.graph.addEdge(classDeclaration.getSuperType(), classDeclaration.getFullyQualifiedName());
             }
         }
         super.visitClassDeclaration(classDeclaration, parameters);
-        parameters.stack.pop();
     }
 
     /**
@@ -276,7 +272,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      */
     visitScalarField(scalar, parameters) {
         super.visitScalarField(scalar, parameters);
-        parameters.graph.addEdge(parameters.stack.slice(-1), scalar.getFullyQualifiedTypeName());
+        parameters.graph.addEdge(scalar.getParent().getFullyQualifiedName(), scalar.getFullyQualifiedTypeName());
     }
 
     /**
@@ -288,7 +284,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
     visitField(field, parameters) {
         super.visitField(field, parameters);
         if (!ModelUtil.isPrimitiveType(field.getFullyQualifiedTypeName())) {
-            parameters.graph.addEdge(parameters.stack.slice(-1), field.getFullyQualifiedTypeName());
+            parameters.graph.addEdge(field.getParent().getFullyQualifiedName(), field.getFullyQualifiedTypeName());
         }
     }
 
@@ -300,7 +296,7 @@ class ConcertoGraphVisitor extends DiagramVisitor {
      */
     visitRelationship(relationship, parameters) {
         super.visitRelationship(relationship, parameters);
-        parameters.graph.addEdge(parameters.stack.slice(-1), relationship.getFullyQualifiedTypeName());
+        parameters.graph.addEdge(relationship.getParent().getFullyQualifiedName(), relationship.getFullyQualifiedTypeName());
     }
 
     /**

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -837,7 +837,7 @@ type Company {
    name: String!
    headquarters: Address!
    companyProperties: CompanyProperties
-   employeeDirectory: EmployeeDirectory
+   employeeDirectory: EmployeeDirectory @category
    employeeTShirtSizes: EmployeeTShirtSizes
    employeeProfiles: EmployeeProfiles
    employeeSocialSecurityNumbers: EmployeeSocialSecurityNumbers
@@ -3214,6 +3214,8 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
          <Property Name="companyProperties" Type="org.acme.hr.CompanyProperties" Nullable="true" >
          </Property>
          <Property Name="employeeDirectory" Type="org.acme.hr.EmployeeDirectory" Nullable="true" >
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="GeneralCategory" />
          </Property>
          <Property Name="employeeTShirtSizes" Type="org.acme.hr.base.EmployeeTShirtSizes" Nullable="true" >
          </Property>
@@ -7582,7 +7584,7 @@ type Company {
    name: String!
    headquarters: Address!
    companyProperties: CompanyProperties
-   employeeDirectory: EmployeeDirectory
+   employeeDirectory: EmployeeDirectory @category
    employeeTShirtSizes: EmployeeTShirtSizes
    employeeProfiles: EmployeeProfiles
    employeeSocialSecurityNumbers: EmployeeSocialSecurityNumbers
@@ -9975,6 +9977,8 @@ exports[`codegen #formats check we can convert all formats from namespace versio
          <Property Name="companyProperties" Type="org.acme.hr.CompanyProperties" Nullable="true" >
          </Property>
          <Property Name="employeeDirectory" Type="org.acme.hr.EmployeeDirectory" Nullable="true" >
+            <Annotation Term="category" Bool="true"/>
+            <Annotation Term="category0" String="GeneralCategory" />
          </Property>
          <Property Name="employeeTShirtSizes" Type="org.acme.hr.base.EmployeeTShirtSizes" Nullable="true" >
          </Property>

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -136,8 +136,21 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 protocol MyProtocol {
 
    import idl "org.acme.hr.base.avdl";
+   import idl "concerto.decorator@1.0.0.avdl";
    import idl "concerto@1.0.0.avdl";
    
+   record pii {
+      boolean isPii;
+      Category category;
+   }
+
+   record Category {
+   }
+
+   record Info {
+      string name;
+   }
+
    record Company {
       string name;
       Address headquarters;
@@ -441,7 +454,29 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   "key": "org.acme.hr.cs",
   "value": "namespace org.acme.hr;
 using org.acme.hr.base;
+using concerto.decorator;
 using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "pii")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class pii : concerto.decorator.Decorator {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.pii";
+   public bool isPii { get; set; }
+   public Category category { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Category")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Category : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Category";
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Info")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Info : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Info";
+   public string name { get; set; }
+}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Company")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public class Company : Concept {
@@ -685,8 +720,21 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 package org_acme_hr
 import "time"
 import "org_acme_hr_base";
+import "concerto_decorator_1_0_0";
 import "concerto_1_0_0";
    
+type pii struct {
+   concerto_decorator_1_0_0.Decorator
+   IsPii bool \`json:"isPii"\`
+   Category Category \`json:"category"\`
+}
+type Category struct {
+   concerto_1_0_0.Concept
+}
+type Info struct {
+   concerto_1_0_0.Concept
+   Name string \`json:"name"\`
+}
 type Company struct {
    concerto_1_0_0.Concept
    Name string \`json:"name"\`
@@ -770,7 +818,8 @@ type ChangeOfAddress struct {
 exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'graphql' 1`] = `
 {
   "key": "model.gql",
-  "value": "directive @category on OBJECT | FIELD_DEFINITION
+  "value": "directive @pii(false: String) on OBJECT | FIELD_DEFINITION
+directive @category on OBJECT | FIELD_DEFINITION
 directive @resource on OBJECT | FIELD_DEFINITION
 directive @test on OBJECT | FIELD_DEFINITION
 scalar DateTime
@@ -809,6 +858,16 @@ enum Level {
    _: Boolean
 }
 # namespace org.acme.hr
+type pii {
+   isPii: Boolean!
+   category: Category!
+}
+type Category {
+   _: Boolean
+}
+type Info {
+   name: String! @pii(false: "Category")
+}
 type CompanyProperties {
    key: String
    value: String
@@ -1269,6 +1328,111 @@ public enum Level {
 
 exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 14`] = `
 {
+  "key": "org/acme/hr/pii.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class pii extends Decorator {
+   private boolean isPii;
+   private Category category;
+   public boolean getIsPii() {
+      return this.isPii;
+   }
+   public Category getCategory() {
+      return this.category;
+   }
+   public void setIsPii(boolean isPii) {
+      this.isPii = isPii;
+   }
+   public void setCategory(Category category) {
+      this.category = category;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 15`] = `
+{
+  "key": "org/acme/hr/Category.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Category extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 16`] = `
+{
+  "key": "org/acme/hr/Info.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Info extends Concept {
+   private String name;
+   public String getName() {
+      return this.name;
+   }
+   public void setName(String name) {
+      this.name = name;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 17`] = `
+{
   "key": "org/acme/hr/Company.java",
   "value": "// this code is generated and should not be modified
 package org.acme.hr;
@@ -1280,6 +1444,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1345,7 +1510,7 @@ public class Company extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 15`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 18`] = `
 {
   "key": "org/acme/hr/Department.java",
   "value": "// this code is generated and should not be modified
@@ -1365,7 +1530,7 @@ public enum Department {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 16`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 19`] = `
 {
   "key": "org/acme/hr/Equipment.java",
   "value": "// this code is generated and should not be modified
@@ -1378,6 +1543,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1406,7 +1572,7 @@ public abstract class Equipment extends Asset {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 17`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 20`] = `
 {
   "key": "org/acme/hr/LaptopMake.java",
   "value": "// this code is generated and should not be modified
@@ -1422,7 +1588,7 @@ public enum LaptopMake {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 18`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 21`] = `
 {
   "key": "org/acme/hr/Laptop.java",
   "value": "// this code is generated and should not be modified
@@ -1435,6 +1601,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1463,7 +1630,7 @@ public class Laptop extends Equipment {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 19`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 22`] = `
 {
   "key": "org/acme/hr/Person.java",
   "value": "// this code is generated and should not be modified
@@ -1476,6 +1643,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1562,7 +1730,7 @@ public abstract class Person extends Participant {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 20`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 23`] = `
 {
   "key": "org/acme/hr/Employee.java",
   "value": "// this code is generated and should not be modified
@@ -1575,6 +1743,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1652,7 +1821,7 @@ public class Employee extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 21`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 24`] = `
 {
   "key": "org/acme/hr/Contractor.java",
   "value": "// this code is generated and should not be modified
@@ -1665,6 +1834,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1700,7 +1870,7 @@ public class Contractor extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 22`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 25`] = `
 {
   "key": "org/acme/hr/Manager.java",
   "value": "// this code is generated and should not be modified
@@ -1713,6 +1883,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1741,7 +1912,7 @@ public class Manager extends Employee {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 23`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 26`] = `
 {
   "key": "org/acme/hr/CompanyEvent.java",
   "value": "// this code is generated and should not be modified
@@ -1754,6 +1925,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1767,7 +1939,7 @@ public class CompanyEvent extends Event {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 24`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 27`] = `
 {
   "key": "org/acme/hr/Onboarded.java",
   "value": "// this code is generated and should not be modified
@@ -1780,6 +1952,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1800,7 +1973,7 @@ public class Onboarded extends CompanyEvent {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 25`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO, format 'java' 28`] = `
 {
   "key": "org/acme/hr/ChangeOfAddress.java",
   "value": "// this code is generated and should not be modified
@@ -1813,6 +1986,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -1946,6 +2120,76 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
     "org.acme.hr.base.SSN": {
       "type": "string",
       "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+    },
+    "org.acme.hr.pii": {
+      "title": "pii",
+      "description": "An instance of org.acme.hr.pii",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.pii",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.pii$",
+          "description": "The class identifier for org.acme.hr.pii"
+        },
+        "isPii": {
+          "type": "boolean"
+        },
+        "category": {
+          "$ref": "#/definitions/org.acme.hr.Category"
+        }
+      },
+      "required": [
+        "$class",
+        "isPii",
+        "category"
+      ]
+    },
+    "org.acme.hr.Category": {
+      "title": "Category",
+      "description": "An instance of org.acme.hr.Category",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Category",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Category$",
+          "description": "The class identifier for org.acme.hr.Category"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
+    "org.acme.hr.Info": {
+      "title": "Info",
+      "description": "An instance of org.acme.hr.Info",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Info",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Info$",
+          "description": "The class identifier for org.acme.hr.Info"
+        },
+        "name": {
+          "type": "string",
+          "$decorators": {
+            "pii": [
+              false,
+              {
+                "type": "Identifier",
+                "name": "Category",
+                "array": false
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "$class",
+        "name"
+      ]
     },
     "org.acme.hr.Company": {
       "title": "Company",
@@ -2660,7 +2904,7 @@ class \`org.acme.hr.base.Level\`
 # Namespace org.acme.hr
 
 ## Overview
-- 1 concepts
+- 4 concepts
 - 2 enumerations
 - 6 maps
 - 2 scalars
@@ -2668,7 +2912,7 @@ class \`org.acme.hr.base.Level\`
 - 4 participants
 - 1 transactions
 - 2 events
-- 20 total declarations
+- 23 total declarations
 
 ## Imports
 - org.acme.hr.base.Address
@@ -2678,6 +2922,7 @@ class \`org.acme.hr.base.Level\`
 - org.acme.hr.base.EmployeeTShirtSizes
 - org.acme.hr.base.Level
 - org.acme.hr.base.GeneralCategory
+- concerto.decorator@1.0.0.Decorator
 - concerto@1.0.0.Concept
 - concerto@1.0.0.Asset
 - concerto@1.0.0.Transaction
@@ -2687,6 +2932,22 @@ class \`org.acme.hr.base.Level\`
 ## Diagram
 \`\`\`mermaid
 classDiagram
+class \`org.acme.hr.pii\` {
+<< concept>>
+   + Boolean isPii
+   + Category category
+}
+
+\`org.acme.hr.pii\` "1" *-- "1" \`org.acme.hr.Category\`
+\`org.acme.hr.pii\` --|> \`concerto.decorator@1.0.0.Decorator\`
+class \`org.acme.hr.Category\`
+<< concept>> \`org.acme.hr.Category\`
+
+class \`org.acme.hr.Info\` {
+<< concept>>
+   + String name
+}
+
 class \`org.acme.hr.CompanyProperties\` {
 << map >>
    + Key:\`String\`
@@ -2892,6 +3153,23 @@ class \`org.acme.hr.base.Level\`
 << enumeration>> \`org.acme.hr.base.Level\`
 
 \`org.acme.hr.base.Level\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr.pii\` {
+<< concept>>
+   + Boolean isPii
+   + Category category
+}
+
+\`org.acme.hr.pii\` --|> \`concerto.decorator@1.0.0.Decorator\`
+class \`org.acme.hr.Category\`
+<< concept>> \`org.acme.hr.Category\`
+
+\`org.acme.hr.Category\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr.Info\` {
+<< concept>>
+   + String name
+}
+
+\`org.acme.hr.Info\` --|> \`concerto@1.0.0.Concept\`
 class \`org.acme.hr.CompanyProperties\` {
 << map >>
    + Key:\`String\`
@@ -3177,11 +3455,29 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 <edmx:Reference Uri="./org.acme.hr.base.csdl">
    <edmx:Include Namespace="org.acme.hr.base" />
 </edmx:Reference>
+<edmx:Reference Uri="./concerto.decorator.csdl">
+   <edmx:Include Namespace="concerto.decorator" />
+</edmx:Reference>
 <edmx:Reference Uri="./concerto.csdl">
    <edmx:Include Namespace="concerto" />
 </edmx:Reference>
 <edmx:DataServices>
    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.acme.hr">
+      <ComplexType Name="pii"  BaseType="concerto.decorator.Decorator">
+         <Property Name="isPii" Type="Edm.Boolean"  >
+         </Property>
+         <Property Name="category" Type="org.acme.hr.Category"  >
+         </Property>
+      </ComplexType>
+      <ComplexType Name="Category"  BaseType="concerto.Concept">
+      </ComplexType>
+      <ComplexType Name="Info"  BaseType="concerto.Concept">
+         <Property Name="name" Type="Edm.String"  >
+            <Annotation Term="pii" Bool="true"/>
+            <Annotation Term="pii0" Bool="false" />
+            <Annotation Term="pii1" String="Category" />
+         </Property>
+      </ComplexType>
    <ComplexType Name="CompanyProperties">
       <Property Name="Key" Type="Edm.String"/>
       <Property Name="Value" Type="Edm.String"/>
@@ -3448,6 +3744,76 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
       "org.acme.hr.base.SSN": {
         "type": "string",
         "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+      },
+      "org.acme.hr.pii": {
+        "title": "pii",
+        "description": "An instance of org.acme.hr.pii",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.pii",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.pii$",
+            "description": "The class identifier for org.acme.hr.pii"
+          },
+          "isPii": {
+            "type": "boolean"
+          },
+          "category": {
+            "$ref": "#/components/schemas/org.acme.hr.Category"
+          }
+        },
+        "required": [
+          "$class",
+          "isPii",
+          "category"
+        ]
+      },
+      "org.acme.hr.Category": {
+        "title": "Category",
+        "description": "An instance of org.acme.hr.Category",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Category",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Category$",
+            "description": "The class identifier for org.acme.hr.Category"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "org.acme.hr.Info": {
+        "title": "Info",
+        "description": "An instance of org.acme.hr.Info",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Info",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Info$",
+            "description": "The class identifier for org.acme.hr.Info"
+          },
+          "name": {
+            "type": "string",
+            "$decorators": {
+              "pii": [
+                false,
+                {
+                  "type": "Identifier",
+                  "name": "Category",
+                  "array": false
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
       },
       "org.acme.hr.Company": {
         "title": "Company",
@@ -4378,6 +4744,18 @@ org.acme.hr.base.Address --|> concerto_1_0_0.Concept
 class org.acme.hr.base.Level << (E,grey) >> {
 }
 org.acme.hr.base.Level --|> concerto_1_0_0.Concept
+class org.acme.hr.pii {
+   + Boolean isPii
+   + Category category
+}
+org.acme.hr.pii --|> concerto.decorator_1_0_0.Decorator
+class org.acme.hr.Category {
+}
+org.acme.hr.Category --|> concerto_1_0_0.Concept
+class org.acme.hr.Info {
+   + String name
+}
+org.acme.hr.Info --|> concerto_1_0_0.Concept
 map "org.acme.hr.CompanyProperties: Map<String, String>" as org.acme.hr.CompanyProperties {
 }
 map "org.acme.hr.EmployeeLoginTimes: Map<String, Time>" as org.acme.hr.EmployeeLoginTimes {
@@ -4523,6 +4901,18 @@ package org.acme.hr.v;
 
 import "google/protobuf/timestamp.proto";
 import "org.acme.hr.base.v.proto";
+import "concerto.decorator.v1_0_0.proto";
+
+message pii {
+  Category category = 1;
+  bool isPii = 2;
+}
+
+message Category {}
+
+message Info {
+  string name = 1;
+}
 
 message Company {
   optional map<string, string> CompanyProperties = 1;
@@ -4993,10 +5383,50 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 use chrono::{ DateTime, TimeZone, Utc };
    
 use crate::org_acme_hr_base::*;
+use crate::concerto_decorator_1_0_0::*;
 use crate::concerto_1_0_0::*;
 use std::collections::HashMap;
 use crate::utils::*;
    
+#[derive(Debug, Serialize, Deserialize)]
+pub struct pii {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "isPii",
+   )]
+   pub is_pii: bool,
+   
+   #[serde(
+      rename = "category",
+   )]
+   pub category: Category,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Info {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "name",
+   )]
+   pub name: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Company {
    #[serde(
@@ -5508,11 +5938,18 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 // Generated code for namespace: concerto.decorator@1.0.0
 
 // imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	Ipii
+} from './org.acme.hr';
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
 export interface IDecorator extends IConcept {
 }
+
+export type DecoratorUnion = Ipii;
 
 export interface IDotNetNamespace extends IDecorator {
    namespace: string;
@@ -5539,6 +5976,8 @@ import type {
 	Level
 } from './org.acme.hr.base';
 import type {
+	ICategory,
+	IInfo,
 	ICompany,
 	Department,
 	LaptopMake
@@ -5571,6 +6010,8 @@ export interface IConcept {
 
 export type ConceptUnion = ICategory | 
 IAddress | 
+ICategory | 
+IInfo | 
 ICompany;
 
 export interface IAsset extends IConcept {
@@ -5700,9 +6141,22 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 
 // Warning: Beware of circular dependencies when modifying these imports
 import {IAddress,IEmployeeTShirtSizes,ISSN} from './org.acme.hr.base';
+import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 
 // interfaces
+export interface Ipii extends IDecorator {
+   isPii: boolean;
+   category: ICategory;
+}
+
+export interface ICategory extends IConcept {
+}
+
+export interface IInfo extends IConcept {
+   name: string;
+}
+
 export type CompanyProperties = Map<string, string>;
 
 export type EmployeeLoginTimes = Map<string, Date>;
@@ -5851,6 +6305,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
 locale: en
 namespace: org.acme.hr
 declarations:
+  - pii: Pii
+    properties:
+      - isPii: Is Pii of thepii
+      - category: Category of thepii
+  - Category: Category
+  - Info: Info
+    properties:
+      - name: Name of the Info
   - CompanyProperties: Company Properties
     properties:
       - KEY: KEY of the Company Properties
@@ -6178,10 +6640,42 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
   "value": "<?xml version="1.0"?>
 <xs:schema xmlns:org.acme.hr="org.acme.hr" targetNamespace="org.acme.hr" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
 xmlns:org.acme.hr.base="org.acme.hr.base"
+xmlns:concerto.decorator="concerto.decorator"
 xmlns:concerto="concerto"
 >
 <xs:import namespace="org.acme.hr.base" schemaLocation="org.acme.hr.base.xsd"/>
+<xs:import namespace="concerto.decorator" schemaLocation="concerto.decorator@1.0.0.xsd"/>
 <xs:import namespace="concerto" schemaLocation="concerto@1.0.0.xsd"/>
+<xs:complexType name="pii">
+   <xs:complexContent>
+   <xs:extension base="concerto.decorator:Decorator">
+   <xs:sequence>
+      <xs:element name="isPii" type="xs:boolean"/>
+      <xs:element name="category" type="org.acme.hr:Category"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="pii" type="org.acme.hr:pii"/>
+<xs:complexType name="Category">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Category" type="org.acme.hr:Category"/>
+<xs:complexType name="Info">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Info" type="org.acme.hr:Info"/>
 <xs:element name="CompanyProperties">
 <xs:complexType>
    <xs:sequence>
@@ -6452,6 +6946,22 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 class \`org.acme.hr.base@1.0.0.Level\`
 << enumeration>> \`org.acme.hr.base@1.0.0.Level\`
 
+class \`org.acme.hr@1.0.0.pii\` {
+<< concept>>
+   + Boolean isPii
+   + Category category
+}
+
+\`org.acme.hr@1.0.0.pii\` "1" *-- "1" \`org.acme.hr@1.0.0.Category\`
+\`org.acme.hr@1.0.0.pii\` --|> \`concerto.decorator@1.0.0.Decorator\`
+class \`org.acme.hr@1.0.0.Category\`
+<< concept>> \`org.acme.hr@1.0.0.Category\`
+
+class \`org.acme.hr@1.0.0.Info\` {
+<< concept>>
+   + String name
+}
+
 class \`org.acme.hr@1.0.0.CompanyProperties\` {
 << map >>
    + Key:\`String\`
@@ -6640,6 +7150,17 @@ class org.acme.hr.base_1_0_0.Address {
 }
 org.acme.hr.base_1_0_0.Address "1" *-- "1" org.acme.hr.base_1_0_0.State : state
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
+}
+class org.acme.hr_1_0_0.pii {
+   + Boolean isPii
+   + Category category
+}
+org.acme.hr_1_0_0.pii "1" *-- "1" org.acme.hr_1_0_0.Category : category
+org.acme.hr_1_0_0.pii --|> concerto.decorator_1_0_0.Decorator
+class org.acme.hr_1_0_0.Category {
+}
+class org.acme.hr_1_0_0.Info {
+   + String name
 }
 map "org.acme.hr_1_0_0.CompanyProperties: Map<String, String>" as org.acme.hr_1_0_0.CompanyProperties {
 }
@@ -6883,8 +7404,21 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 protocol MyProtocol {
 
    import idl "org.acme.hr.base@1.0.0.avdl";
+   import idl "concerto.decorator@1.0.0.avdl";
    import idl "concerto@1.0.0.avdl";
    
+   record pii {
+      boolean isPii;
+      Category category;
+   }
+
+   record Category {
+   }
+
+   record Info {
+      string name;
+   }
+
    record Company {
       string name;
       Address headquarters;
@@ -7188,7 +7722,29 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "key": "org.acme.hr@1.0.0.cs",
   "value": "namespace org.acme.hr;
 using org.acme.hr.base;
+using concerto.decorator;
 using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "pii")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class pii : concerto.decorator.Decorator {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr@1.0.0.pii";
+   public bool isPii { get; set; }
+   public Category category { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Category")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Category : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr@1.0.0.Category";
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Info")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Info : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr@1.0.0.Info";
+   public string name { get; set; }
+}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Company")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public class Company : Concept {
@@ -7432,8 +7988,21 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 package org_acme_hr_1_0_0
 import "time"
 import "org_acme_hr_base_1_0_0";
+import "concerto_decorator_1_0_0";
 import "concerto_1_0_0";
    
+type pii struct {
+   concerto_decorator_1_0_0.Decorator
+   IsPii bool \`json:"isPii"\`
+   Category Category \`json:"category"\`
+}
+type Category struct {
+   concerto_1_0_0.Concept
+}
+type Info struct {
+   concerto_1_0_0.Concept
+   Name string \`json:"name"\`
+}
 type Company struct {
    concerto_1_0_0.Concept
    Name string \`json:"name"\`
@@ -7517,7 +8086,8 @@ type ChangeOfAddress struct {
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'graphql' 1`] = `
 {
   "key": "model.gql",
-  "value": "directive @category on OBJECT | FIELD_DEFINITION
+  "value": "directive @pii(false: String) on OBJECT | FIELD_DEFINITION
+directive @category on OBJECT | FIELD_DEFINITION
 directive @resource on OBJECT | FIELD_DEFINITION
 directive @test on OBJECT | FIELD_DEFINITION
 scalar DateTime
@@ -7556,6 +8126,16 @@ enum Level {
    _: Boolean
 }
 # namespace org.acme.hr@1.0.0
+type pii {
+   isPii: Boolean!
+   category: Category!
+}
+type Category {
+   _: Boolean
+}
+type Info {
+   name: String! @pii(false: "Category")
+}
 type CompanyProperties {
    key: String
    value: String
@@ -8016,6 +8596,111 @@ public enum Level {
 
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 14`] = `
 {
+  "key": "org/acme/hr/pii.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class pii extends Decorator {
+   private boolean isPii;
+   private Category category;
+   public boolean getIsPii() {
+      return this.isPii;
+   }
+   public Category getCategory() {
+      return this.category;
+   }
+   public void setIsPii(boolean isPii) {
+      this.isPii = isPii;
+   }
+   public void setCategory(Category category) {
+      this.category = category;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 15`] = `
+{
+  "key": "org/acme/hr/Category.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Category extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 16`] = `
+{
+  "key": "org/acme/hr/Info.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import org.acme.hr.base.Address;
+import org.acme.hr.base.State;
+import org.acme.hr.base.SSN;
+import org.acme.hr.base.Time;
+import org.acme.hr.base.EmployeeTShirtSizes;
+import org.acme.hr.base.Level;
+import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Info extends Concept {
+   private String name;
+   public String getName() {
+      return this.name;
+   }
+   public void setName(String name) {
+      this.name = name;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 17`] = `
+{
   "key": "org/acme/hr/Company.java",
   "value": "// this code is generated and should not be modified
 package org.acme.hr;
@@ -8027,6 +8712,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8092,7 +8778,7 @@ public class Company extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 15`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 18`] = `
 {
   "key": "org/acme/hr/Department.java",
   "value": "// this code is generated and should not be modified
@@ -8112,7 +8798,7 @@ public enum Department {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 16`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 19`] = `
 {
   "key": "org/acme/hr/Equipment.java",
   "value": "// this code is generated and should not be modified
@@ -8125,6 +8811,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8153,7 +8840,7 @@ public abstract class Equipment extends Asset {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 17`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 20`] = `
 {
   "key": "org/acme/hr/LaptopMake.java",
   "value": "// this code is generated and should not be modified
@@ -8169,7 +8856,7 @@ public enum LaptopMake {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 18`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 21`] = `
 {
   "key": "org/acme/hr/Laptop.java",
   "value": "// this code is generated and should not be modified
@@ -8182,6 +8869,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8210,7 +8898,7 @@ public class Laptop extends Equipment {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 19`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 22`] = `
 {
   "key": "org/acme/hr/Person.java",
   "value": "// this code is generated and should not be modified
@@ -8223,6 +8911,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8309,7 +8998,7 @@ public abstract class Person extends Participant {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 20`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 23`] = `
 {
   "key": "org/acme/hr/Employee.java",
   "value": "// this code is generated and should not be modified
@@ -8322,6 +9011,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8399,7 +9089,7 @@ public class Employee extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 21`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 24`] = `
 {
   "key": "org/acme/hr/Contractor.java",
   "value": "// this code is generated and should not be modified
@@ -8412,6 +9102,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8447,7 +9138,7 @@ public class Contractor extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 22`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 25`] = `
 {
   "key": "org/acme/hr/Manager.java",
   "value": "// this code is generated and should not be modified
@@ -8460,6 +9151,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8488,7 +9180,7 @@ public class Manager extends Employee {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 23`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 26`] = `
 {
   "key": "org/acme/hr/CompanyEvent.java",
   "value": "// this code is generated and should not be modified
@@ -8501,6 +9193,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8514,7 +9207,7 @@ public class CompanyEvent extends Event {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 24`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 27`] = `
 {
   "key": "org/acme/hr/Onboarded.java",
   "value": "// this code is generated and should not be modified
@@ -8527,6 +9220,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8547,7 +9241,7 @@ public class Onboarded extends CompanyEvent {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 25`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'java' 28`] = `
 {
   "key": "org/acme/hr/ChangeOfAddress.java",
   "value": "// this code is generated and should not be modified
@@ -8560,6 +9254,7 @@ import org.acme.hr.base.Time;
 import org.acme.hr.base.EmployeeTShirtSizes;
 import org.acme.hr.base.Level;
 import org.acme.hr.base.GeneralCategory;
+import concerto.decorator.Decorator;
 import concerto.Concept;
 import concerto.Asset;
 import concerto.Transaction;
@@ -8693,6 +9388,76 @@ exports[`codegen #formats check we can convert all formats from namespace versio
     "org.acme.hr.base@1.0.0.SSN": {
       "type": "string",
       "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+    },
+    "org.acme.hr@1.0.0.pii": {
+      "title": "pii",
+      "description": "An instance of org.acme.hr@1.0.0.pii",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr@1.0.0.pii",
+          "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.pii$",
+          "description": "The class identifier for org.acme.hr@1.0.0.pii"
+        },
+        "isPii": {
+          "type": "boolean"
+        },
+        "category": {
+          "$ref": "#/definitions/org.acme.hr@1.0.0.Category"
+        }
+      },
+      "required": [
+        "$class",
+        "isPii",
+        "category"
+      ]
+    },
+    "org.acme.hr@1.0.0.Category": {
+      "title": "Category",
+      "description": "An instance of org.acme.hr@1.0.0.Category",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr@1.0.0.Category",
+          "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.Category$",
+          "description": "The class identifier for org.acme.hr@1.0.0.Category"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
+    "org.acme.hr@1.0.0.Info": {
+      "title": "Info",
+      "description": "An instance of org.acme.hr@1.0.0.Info",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr@1.0.0.Info",
+          "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.Info$",
+          "description": "The class identifier for org.acme.hr@1.0.0.Info"
+        },
+        "name": {
+          "type": "string",
+          "$decorators": {
+            "pii": [
+              false,
+              {
+                "type": "Identifier",
+                "name": "Category",
+                "array": false
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "$class",
+        "name"
+      ]
     },
     "org.acme.hr@1.0.0.Company": {
       "title": "Company",
@@ -9407,7 +10172,7 @@ class \`org.acme.hr.base@1.0.0.Level\`
 # Namespace org.acme.hr@1.0.0
 
 ## Overview
-- 1 concepts
+- 4 concepts
 - 2 enumerations
 - 6 maps
 - 2 scalars
@@ -9415,7 +10180,7 @@ class \`org.acme.hr.base@1.0.0.Level\`
 - 4 participants
 - 1 transactions
 - 2 events
-- 20 total declarations
+- 23 total declarations
 
 ## Imports
 - org.acme.hr.base@1.0.0.Address
@@ -9425,6 +10190,7 @@ class \`org.acme.hr.base@1.0.0.Level\`
 - org.acme.hr.base@1.0.0.EmployeeTShirtSizes
 - org.acme.hr.base@1.0.0.Level
 - org.acme.hr.base@1.0.0.GeneralCategory
+- concerto.decorator@1.0.0.Decorator
 - concerto@1.0.0.Concept
 - concerto@1.0.0.Asset
 - concerto@1.0.0.Transaction
@@ -9434,6 +10200,22 @@ class \`org.acme.hr.base@1.0.0.Level\`
 ## Diagram
 \`\`\`mermaid
 classDiagram
+class \`org.acme.hr@1.0.0.pii\` {
+<< concept>>
+   + Boolean isPii
+   + Category category
+}
+
+\`org.acme.hr@1.0.0.pii\` "1" *-- "1" \`org.acme.hr@1.0.0.Category\`
+\`org.acme.hr@1.0.0.pii\` --|> \`concerto.decorator@1.0.0.Decorator\`
+class \`org.acme.hr@1.0.0.Category\`
+<< concept>> \`org.acme.hr@1.0.0.Category\`
+
+class \`org.acme.hr@1.0.0.Info\` {
+<< concept>>
+   + String name
+}
+
 class \`org.acme.hr@1.0.0.CompanyProperties\` {
 << map >>
    + Key:\`String\`
@@ -9640,6 +10422,24 @@ class \`org.acme.hr.base@1.0.0.Level\`
 << enumeration>> \`org.acme.hr.base@1.0.0.Level\`
 
 \`org.acme.hr.base@1.0.0.Level\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr@1.0.0.pii\` {
+<< concept>>
+   + Boolean isPii
+   + Category category
+}
+
+\`org.acme.hr@1.0.0.pii\` "1" *-- "1" \`org.acme.hr@1.0.0.Category\`
+\`org.acme.hr@1.0.0.pii\` --|> \`concerto.decorator@1.0.0.Decorator\`
+class \`org.acme.hr@1.0.0.Category\`
+<< concept>> \`org.acme.hr@1.0.0.Category\`
+
+\`org.acme.hr@1.0.0.Category\` --|> \`concerto@1.0.0.Concept\`
+class \`org.acme.hr@1.0.0.Info\` {
+<< concept>>
+   + String name
+}
+
+\`org.acme.hr@1.0.0.Info\` --|> \`concerto@1.0.0.Concept\`
 class \`org.acme.hr@1.0.0.CompanyProperties\` {
 << map >>
    + Key:\`String\`
@@ -9940,11 +10740,29 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 <edmx:Reference Uri="./org.acme.hr.base.csdl">
    <edmx:Include Namespace="org.acme.hr.base" />
 </edmx:Reference>
+<edmx:Reference Uri="./concerto.decorator.csdl">
+   <edmx:Include Namespace="concerto.decorator" />
+</edmx:Reference>
 <edmx:Reference Uri="./concerto.csdl">
    <edmx:Include Namespace="concerto" />
 </edmx:Reference>
 <edmx:DataServices>
    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.acme.hr">
+      <ComplexType Name="pii"  BaseType="concerto.decorator.Decorator">
+         <Property Name="isPii" Type="Edm.Boolean"  >
+         </Property>
+         <Property Name="category" Type="org.acme.hr.Category"  >
+         </Property>
+      </ComplexType>
+      <ComplexType Name="Category"  BaseType="concerto.Concept">
+      </ComplexType>
+      <ComplexType Name="Info"  BaseType="concerto.Concept">
+         <Property Name="name" Type="Edm.String"  >
+            <Annotation Term="pii" Bool="true"/>
+            <Annotation Term="pii0" Bool="false" />
+            <Annotation Term="pii1" String="Category" />
+         </Property>
+      </ComplexType>
    <ComplexType Name="CompanyProperties">
       <Property Name="Key" Type="Edm.String"/>
       <Property Name="Value" Type="Edm.String"/>
@@ -10211,6 +11029,76 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       "org.acme.hr.base@1.0.0.SSN": {
         "type": "string",
         "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+      },
+      "org.acme.hr@1.0.0.pii": {
+        "title": "pii",
+        "description": "An instance of org.acme.hr@1.0.0.pii",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr@1.0.0.pii",
+            "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.pii$",
+            "description": "The class identifier for org.acme.hr@1.0.0.pii"
+          },
+          "isPii": {
+            "type": "boolean"
+          },
+          "category": {
+            "$ref": "#/components/schemas/org.acme.hr@1.0.0.Category"
+          }
+        },
+        "required": [
+          "$class",
+          "isPii",
+          "category"
+        ]
+      },
+      "org.acme.hr@1.0.0.Category": {
+        "title": "Category",
+        "description": "An instance of org.acme.hr@1.0.0.Category",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr@1.0.0.Category",
+            "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.Category$",
+            "description": "The class identifier for org.acme.hr@1.0.0.Category"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "org.acme.hr@1.0.0.Info": {
+        "title": "Info",
+        "description": "An instance of org.acme.hr@1.0.0.Info",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr@1.0.0.Info",
+            "pattern": "^org\\\\.acme\\\\.hr@1\\\\.0\\\\.0\\\\.Info$",
+            "description": "The class identifier for org.acme.hr@1.0.0.Info"
+          },
+          "name": {
+            "type": "string",
+            "$decorators": {
+              "pii": [
+                false,
+                {
+                  "type": "Identifier",
+                  "name": "Category",
+                  "array": false
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
       },
       "org.acme.hr@1.0.0.Company": {
         "title": "Company",
@@ -11142,6 +12030,19 @@ org.acme.hr.base_1_0_0.Address --|> concerto_1_0_0.Concept
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
 }
 org.acme.hr.base_1_0_0.Level --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.pii {
+   + Boolean isPii
+   + Category category
+}
+org.acme.hr_1_0_0.pii "1" *-- "1" org.acme.hr_1_0_0.Category : category
+org.acme.hr_1_0_0.pii --|> concerto.decorator_1_0_0.Decorator
+class org.acme.hr_1_0_0.Category {
+}
+org.acme.hr_1_0_0.Category --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Info {
+   + String name
+}
+org.acme.hr_1_0_0.Info --|> concerto_1_0_0.Concept
 map "org.acme.hr_1_0_0.CompanyProperties: Map<String, String>" as org.acme.hr_1_0_0.CompanyProperties {
 }
 map "org.acme.hr_1_0_0.EmployeeLoginTimes: Map<String, Time>" as org.acme.hr_1_0_0.EmployeeLoginTimes {
@@ -11302,6 +12203,18 @@ package org.acme.hr.v1_0_0;
 
 import "google/protobuf/timestamp.proto";
 import "org.acme.hr.base.v1_0_0.proto";
+import "concerto.decorator.v1_0_0.proto";
+
+message pii {
+  Category category = 1;
+  bool isPii = 2;
+}
+
+message Category {}
+
+message Info {
+  string name = 1;
+}
 
 message Company {
   optional map<string, string> CompanyProperties = 1;
@@ -11772,10 +12685,50 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 use chrono::{ DateTime, TimeZone, Utc };
    
 use crate::org_acme_hr_base_1_0_0::*;
+use crate::concerto_decorator_1_0_0::*;
 use crate::concerto_1_0_0::*;
 use std::collections::HashMap;
 use crate::utils::*;
    
+#[derive(Debug, Serialize, Deserialize)]
+pub struct pii {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "isPii",
+   )]
+   pub is_pii: bool,
+   
+   #[serde(
+      rename = "category",
+   )]
+   pub category: Category,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Info {
+   #[serde(
+      rename = "$class",
+   )]
+   pub _class: String,
+   
+   #[serde(
+      rename = "name",
+   )]
+   pub name: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Company {
    #[serde(
@@ -12287,11 +13240,18 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: concerto.decorator@1.0.0
 
 // imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	Ipii
+} from './org.acme.hr@1.0.0';
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
 export interface IDecorator extends IConcept {
 }
+
+export type DecoratorUnion = Ipii;
 
 export interface IDotNetNamespace extends IDecorator {
    namespace: string;
@@ -12318,6 +13278,8 @@ import type {
 	Level
 } from './org.acme.hr.base@1.0.0';
 import type {
+	ICategory,
+	IInfo,
 	ICompany,
 	Department,
 	LaptopMake
@@ -12350,6 +13312,8 @@ export interface IConcept {
 
 export type ConceptUnion = ICategory | 
 IAddress | 
+ICategory | 
+IInfo | 
 ICompany;
 
 export interface IAsset extends IConcept {
@@ -12479,9 +13443,22 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 
 // Warning: Beware of circular dependencies when modifying these imports
 import {IAddress,IEmployeeTShirtSizes,ISSN} from './org.acme.hr.base@1.0.0';
+import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 
 // interfaces
+export interface Ipii extends IDecorator {
+   isPii: boolean;
+   category: ICategory;
+}
+
+export interface ICategory extends IConcept {
+}
+
+export interface IInfo extends IConcept {
+   name: string;
+}
+
 export type CompanyProperties = Map<string, string>;
 
 export type EmployeeLoginTimes = Map<string, Date>;
@@ -12630,6 +13607,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 locale: en
 namespace: org.acme.hr@1.0.0
 declarations:
+  - pii: Pii
+    properties:
+      - isPii: Is Pii of thepii
+      - category: Category of thepii
+  - Category: Category
+  - Info: Info
+    properties:
+      - name: Name of the Info
   - CompanyProperties: Company Properties
     properties:
       - KEY: KEY of the Company Properties
@@ -12957,10 +13942,42 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "value": "<?xml version="1.0"?>
 <xs:schema xmlns:org.acme.hr="org.acme.hr" targetNamespace="org.acme.hr" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
 xmlns:org.acme.hr.base="org.acme.hr.base"
+xmlns:concerto.decorator="concerto.decorator"
 xmlns:concerto="concerto"
 >
 <xs:import namespace="org.acme.hr.base" schemaLocation="org.acme.hr.base@1.0.0.xsd"/>
+<xs:import namespace="concerto.decorator" schemaLocation="concerto.decorator@1.0.0.xsd"/>
 <xs:import namespace="concerto" schemaLocation="concerto@1.0.0.xsd"/>
+<xs:complexType name="pii">
+   <xs:complexContent>
+   <xs:extension base="concerto.decorator:Decorator">
+   <xs:sequence>
+      <xs:element name="isPii" type="xs:boolean"/>
+      <xs:element name="category" type="org.acme.hr:Category"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="pii" type="org.acme.hr:pii"/>
+<xs:complexType name="Category">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Category" type="org.acme.hr:Category"/>
+<xs:complexType name="Info">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Info" type="org.acme.hr:Info"/>
 <xs:element name="CompanyProperties">
 <xs:complexType>
    <xs:sequence>

--- a/test/codegen/fromcto/data/model/hr.cto
+++ b/test/codegen/fromcto/data/model/hr.cto
@@ -2,6 +2,19 @@
 namespace org.acme.hr@1.0.0
 
 import org.acme.hr.base@1.0.0.{Address, State, SSN, Time, EmployeeTShirtSizes, Level, GeneralCategory}
+import concerto.decorator@1.0.0.{Decorator}
+
+concept pii extends Decorator {
+   o Boolean isPii
+   o Category category
+}
+
+concept Category {}
+
+concept Info {
+   @pii(false, Category)
+   o String name
+}
 
 map CompanyProperties {
     o String

--- a/test/codegen/fromcto/data/model/hr.cto
+++ b/test/codegen/fromcto/data/model/hr.cto
@@ -14,6 +14,7 @@ map EmployeeLoginTimes {
     o Time
 }
 
+@category(GeneralCategory)
 map EmployeeSocialSecurityNumbers {
     o String
     o SSN
@@ -26,10 +27,12 @@ map NextOfKin {
 
 map EmployeeProfiles {
     o String
+    @category(GeneralCategory)
     o Concept
 }
 
 map EmployeeDirectory {
+    @category(GeneralCategory)
     o SSN
     o Employee
 }
@@ -38,6 +41,7 @@ concept Company {
     o String name regex=/abc.*/
     o Address headquarters
     o CompanyProperties companyProperties optional
+    @category(GeneralCategory)
     o EmployeeDirectory employeeDirectory optional
     o EmployeeTShirtSizes employeeTShirtSizes optional
     o EmployeeProfiles employeeProfiles optional

--- a/test/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/test/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -590,6 +590,19 @@ describe('PlantUMLVisitor', function () {
 
             param.fileWriter.writeLine.withArgs(1, '+ Bob').calledOnce.should.be.ok;
         });
+
+        it('should not write a line for enum value if writer is undefined', () => {
+            let param = {};
+
+
+            let mockEnumValueDecl = sinon.createStubInstance(EnumValueDeclaration);
+            mockEnumValueDecl.isEnumValue.returns(true);
+            mockEnumValueDecl.getName.returns('Bob');
+            mockEnumValueDecl.getDecorators.returns([]);
+
+            plantUMLvisitor.visitField(mockEnumValueDecl, param);
+            mockEnumValueDecl.getName().never;
+        });
     });
 
     describe('visitDecorator', () => {

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -5,7 +5,7 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` --> \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.State\`
    \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.TShirtSizeType\`
@@ -21,9 +21,9 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.pii\` --> \`concerto.decorator@1.0.0.Decorator\`
    \`org.acme.hr@1.0.0.pii\` --> \`org.acme.hr@1.0.0.Category\`
    \`concerto.decorator@1.0.0.Decorator\`
-   \`concerto.decorator@1.0.0.Decorator\` <--> \`org.acme.hr@1.0.0.pii\`
    \`org.acme.hr@1.0.0.Category\`
    \`org.acme.hr@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Info\`
@@ -63,27 +63,27 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
    \`concerto@1.0.0.Asset\`
-   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
    \`concerto@1.0.0.Participant\`
-   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
@@ -91,16 +91,16 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
    \`concerto@1.0.0.Event\`
-   \`concerto@1.0.0.Event\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.Onboarded\`
-   \`org.acme.hr@1.0.0.Onboarded\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`concerto@1.0.0.Transaction\`
-   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
@@ -218,82 +218,27 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` --> \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.State\`
    \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
-   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
    \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
-   \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.NextOfKin\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
-   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
-   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
-   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
-   \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.Equipment\`
-   \`concerto@1.0.0.Asset\`
-   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.LaptopMake\`
-   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
-   \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
    \`concerto@1.0.0.Participant\`
-   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`concerto@1.0.0.Transaction\`
-   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -5,7 +5,7 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr.base@1.0.0.GeneralCategory\` --> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.State\`
    \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.TShirtSizeType\`
@@ -21,8 +21,9 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.pii\`
-   \`org.acme.hr@1.0.0.pii\` --> \`concerto.decorator@1.0.0.Decorator\`
    \`org.acme.hr@1.0.0.pii\` --> \`org.acme.hr@1.0.0.Category\`
+   \`concerto.decorator@1.0.0.Decorator\`
+   \`concerto.decorator@1.0.0.Decorator\` <--> \`org.acme.hr@1.0.0.pii\`
    \`org.acme.hr@1.0.0.Category\`
    \`org.acme.hr@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Info\`
@@ -62,25 +63,27 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
-   \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
+   \`concerto@1.0.0.Asset\`
+   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Laptop\`
-   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`concerto@1.0.0.Participant\`
+   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Employee\`
-   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Contractor\`
-   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
@@ -88,14 +91,16 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.CompanyEvent\`
-   \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
+   \`concerto@1.0.0.Event\`
+   \`concerto@1.0.0.Event\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.Onboarded\`
-   \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
+   \`org.acme.hr@1.0.0.Onboarded\` <--> \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`concerto@1.0.0.Transaction\`
+   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
@@ -213,25 +218,82 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr.base@1.0.0.GeneralCategory\` --> \`org.acme.hr.base@1.0.0.Category\`
+   \`org.acme.hr.base@1.0.0.GeneralCategory\` <--> \`org.acme.hr.base@1.0.0.Category\`
    \`org.acme.hr.base@1.0.0.State\`
    \`org.acme.hr.base@1.0.0.State\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\`
+   \`org.acme.hr.base@1.0.0.TShirtSizeType\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\` --> \`org.acme.hr.base@1.0.0.TShirtSizeType\`
    \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.NextOfKin\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Equipment\`
+   \`concerto@1.0.0.Asset\`
+   \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.LaptopMake\`
+   \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Laptop\`
+   \`org.acme.hr@1.0.0.Laptop\` <--> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Laptop\` --> \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.Person\`
-   \`org.acme.hr@1.0.0.Person\` --> \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
+   \`concerto@1.0.0.Participant\`
+   \`concerto@1.0.0.Participant\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Employee\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Equipment\`
+   \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
+   \`org.acme.hr@1.0.0.Contractor\`
+   \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\`
+   \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
+   \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`concerto@1.0.0.Transaction\`
+   \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -26,21 +26,25 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.NextOfKin\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Company\`
    \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
@@ -121,21 +125,25 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\` --> \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.NextOfKin\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Company\`
    \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`
@@ -208,21 +216,25 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr@1.0.0.CompanyProperties\`
    \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\`
+   \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.NextOfKin\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.NextOfKin\` --> \`org.acme.hr@1.0.0.KinTelephone\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\`
+   \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeProfiles\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\`
+   \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.EmployeeDirectory\` --> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Company\`
    \`org.acme.hr@1.0.0.Company\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.CompanyProperties\`
+   \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeDirectory\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr.base@1.0.0.EmployeeTShirtSizes\`
    \`org.acme.hr@1.0.0.Company\` --> \`org.acme.hr@1.0.0.EmployeeProfiles\`

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -20,6 +20,16 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.pii\` --> \`org.acme.hr@1.0.0.Category\`
+   \`concerto.decorator@1.0.0.Decorator\`
+   \`concerto.decorator@1.0.0.Decorator\` <--> \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.Category\`
+   \`org.acme.hr@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Info\`
+   \`org.acme.hr@1.0.0.Info\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Info\` --> \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.Info\` --> \`org.acme.hr@1.0.0.Category\`
    \`org.acme.hr@1.0.0.CompanyProperties\`
    \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\`
@@ -119,6 +129,15 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.Time\`
    \`org.acme.hr.base@1.0.0.SSN\`
+   \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.pii\` --> \`concerto.decorator@1.0.0.Decorator\`
+   \`org.acme.hr@1.0.0.pii\` --> \`org.acme.hr@1.0.0.Category\`
+   \`org.acme.hr@1.0.0.Category\`
+   \`org.acme.hr@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Info\`
+   \`org.acme.hr@1.0.0.Info\` --> \`concerto@1.0.0.Concept\`
+   \`org.acme.hr@1.0.0.Info\` --> \`org.acme.hr@1.0.0.pii\`
+   \`org.acme.hr@1.0.0.Info\` --> \`org.acme.hr@1.0.0.Category\`
    \`org.acme.hr@1.0.0.CompanyProperties\`
    \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
    \`org.acme.hr@1.0.0.EmployeeLoginTimes\`

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -87,9 +87,8 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
-   \`\`
-   \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
    \`org.acme.hr@1.0.0\`
    \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
@@ -179,9 +178,8 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`\`
-   \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
    \`org.acme.hr@1.0.0\`
    \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
@@ -266,6 +264,7 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
+   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
 "
 `;

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -48,8 +48,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.Department.Sales\`
-   \`org.acme.hr@1.0.0.Department.Sales\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`concerto@1.0.0.Asset\`
    \`concerto@1.0.0.Asset\` <--> \`org.acme.hr@1.0.0.Equipment\`
@@ -73,9 +71,8 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Contractor\`
    \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Manager\`
    \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
@@ -90,11 +87,10 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
+   \`\`
+   \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0\`
-   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 
@@ -146,8 +142,6 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.Department\`
    \`org.acme.hr@1.0.0.Department\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
-   \`org.acme.hr@1.0.0.Department.Sales\`
-   \`org.acme.hr@1.0.0.Department.Sales\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
    \`org.acme.hr@1.0.0.LaptopMake\`
@@ -169,9 +163,8 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.Contractor\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\`
-   \`org.acme.hr@1.0.0.Contractor.manager\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Manager\`
    \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
@@ -184,11 +177,10 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
+   \`\`
+   \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
-   \`org.acme.hr@1.0.0\`
-   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 
@@ -208,6 +200,8 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.Address\` --> \`org.acme.hr.base@1.0.0.State\`
+   \`org.acme.hr.base@1.0.0.Level\`
+   \`org.acme.hr.base@1.0.0.Level\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.CompanyProperties\`
    \`org.acme.hr@1.0.0.CompanyProperties\` --> \`String\`
@@ -257,6 +251,7 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr@1.0.0.Contractor\`
    \`org.acme.hr@1.0.0.Contractor\` <--> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Company\`
+   \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr.base@1.0.0.Level\`
    \`org.acme.hr@1.0.0.Contractor\` --> \`org.acme.hr@1.0.0.Manager\`
    \`org.acme.hr@1.0.0.Manager\`
    \`org.acme.hr@1.0.0.Manager\` <--> \`org.acme.hr@1.0.0.Employee\`
@@ -267,7 +262,6 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`concerto@1.0.0.Transaction\`
    \`concerto@1.0.0.Transaction\` <--> \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.KinName\`
-   \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
 "
 `;

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -91,6 +91,8 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0\`
+   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 
@@ -181,6 +183,8 @@ exports[`graph #visitor should visit a model manager and create a dependency gra
    \`\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinTelephone\`
+   \`org.acme.hr@1.0.0\`
+   \`org.acme.hr@1.0.0\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
 "
 `;
 

--- a/test/common/__snapshots__/graph.js.snap
+++ b/test/common/__snapshots__/graph.js.snap
@@ -23,7 +23,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.pii\`
    \`org.acme.hr@1.0.0.pii\` --> \`concerto.decorator@1.0.0.Decorator\`
    \`org.acme.hr@1.0.0.pii\` --> \`org.acme.hr@1.0.0.Category\`
-   \`concerto.decorator@1.0.0.Decorator\`
    \`org.acme.hr@1.0.0.Category\`
    \`org.acme.hr@1.0.0.Category\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Info\`
@@ -64,7 +63,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Department\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.Equipment\`
    \`org.acme.hr@1.0.0.Equipment\` --> \`concerto@1.0.0.Asset\`
-   \`concerto@1.0.0.Asset\`
    \`org.acme.hr@1.0.0.LaptopMake\`
    \`org.acme.hr@1.0.0.LaptopMake\` --> \`concerto@1.0.0.Concept\`
    \`org.acme.hr@1.0.0.Laptop\`
@@ -75,7 +73,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
-   \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.Employee\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.Employee\` --> \`org.acme.hr@1.0.0.Department\`
@@ -92,7 +89,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.Manager\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.CompanyEvent\` --> \`concerto@1.0.0.Event\`
-   \`concerto@1.0.0.Event\`
    \`org.acme.hr@1.0.0.Onboarded\`
    \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.CompanyEvent\`
    \`org.acme.hr@1.0.0.Onboarded\` --> \`org.acme.hr@1.0.0.Employee\`
@@ -100,7 +96,6 @@ exports[`graph #visitor should visit a model manager 1`] = `
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`
@@ -233,12 +228,10 @@ exports[`graph #visitor should visit find a connected subgraph 1`] = `
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.Address\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr.base@1.0.0.SSN\`
    \`org.acme.hr@1.0.0.Person\` --> \`org.acme.hr@1.0.0.NextOfKin\`
-   \`concerto@1.0.0.Participant\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr@1.0.0.Person\`
    \`org.acme.hr@1.0.0.ChangeOfAddress\` --> \`org.acme.hr.base@1.0.0.Address\`
-   \`concerto@1.0.0.Transaction\`
    \`org.acme.hr@1.0.0.KinName\`
    \`org.acme.hr@1.0.0.KinName\` --> \`org.acme.hr.base@1.0.0.GeneralCategory\`
    \`org.acme.hr@1.0.0.KinTelephone\`

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -90,7 +90,7 @@ describe('graph', function() {
             expect(filteredModelManager.getModelFiles()).toHaveLength(2);
             expect(
                 filteredModelManager.getModelFiles()[0].getAllDeclarations()
-            ).toHaveLength(5);
+            ).toHaveLength(8);
 
             writer.openFile('graph.mmd');
             connectedGraph.print(writer);

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -57,7 +57,7 @@ describe('graph', function() {
             const writer = new InMemoryWriter();
 
             const graph = new DirectedGraph();
-            modelManager.accept(visitor, { graph });
+            modelManager.accept(visitor, { graph, includeDerivedTypes: true });
 
             writer.openFile('graph.mmd');
             graph.print(writer);
@@ -71,7 +71,7 @@ describe('graph', function() {
             const writer = new InMemoryWriter();
 
             const graph = new DirectedGraph();
-            modelManager.accept(visitor, { graph });
+            modelManager.accept(visitor, { graph, includeDerivedTypes: true });
 
             const connectedGraph = graph.findConnectedGraph(
                 'org.acme.hr@1.0.0.ChangeOfAddress'
@@ -106,7 +106,7 @@ describe('graph', function() {
             const graph = new DirectedGraph();
             modelManager.accept(visitor, {
                 graph,
-                createDependencyGraph: true
+                includeDerivedTypes: false
             });
 
             expect(

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -82,12 +82,6 @@ describe('graph', function() {
                     'org.acme.hr@1.0.0.Person'
                 )
             );
-            expect(
-                connectedGraph.hasEdge(
-                    'org.acme.hr@1.0.0.Contractor',
-                    'org.acme.hr.base@1.0.0.Level'
-                )
-            );
 
             const filteredModelManager = modelManager.filter((declaration) =>
                 connectedGraph.hasVertex(declaration.getFullyQualifiedName())
@@ -96,7 +90,7 @@ describe('graph', function() {
             expect(filteredModelManager.getModelFiles()).toHaveLength(2);
             expect(
                 filteredModelManager.getModelFiles()[0].getAllDeclarations()
-            ).toHaveLength(8);
+            ).toHaveLength(5);
 
             writer.openFile('graph.mmd');
             connectedGraph.print(writer);
@@ -114,6 +108,13 @@ describe('graph', function() {
                 graph,
                 createDependencyGraph: true
             });
+
+            expect(
+                graph.hasEdge(
+                    'org.acme.hr@1.0.0.Contractor',
+                    'org.acme.hr.base@1.0.0.Level'
+                )
+            );
 
             writer.openFile('graph.mmd');
             graph.print(writer);

--- a/test/common/graph.js
+++ b/test/common/graph.js
@@ -82,6 +82,12 @@ describe('graph', function() {
                     'org.acme.hr@1.0.0.Person'
                 )
             );
+            expect(
+                connectedGraph.hasEdge(
+                    'org.acme.hr@1.0.0.Contractor',
+                    'org.acme.hr.base@1.0.0.Level'
+                )
+            );
 
             const filteredModelManager = modelManager.filter((declaration) =>
                 connectedGraph.hasVertex(declaration.getFullyQualifiedName())
@@ -90,7 +96,7 @@ describe('graph', function() {
             expect(filteredModelManager.getModelFiles()).toHaveLength(2);
             expect(
                 filteredModelManager.getModelFiles()[0].getAllDeclarations()
-            ).toHaveLength(7);
+            ).toHaveLength(8);
 
             writer.openFile('graph.mmd');
             connectedGraph.print(writer);

--- a/types/lib/common/basevisitor.d.ts
+++ b/types/lib/common/basevisitor.d.ts
@@ -1,0 +1,131 @@
+export = BaseVisitor;
+/**
+ * Visitor class that traverses various model elements
+ *
+ * @protected
+ * @class
+ */
+declare class BaseVisitor {
+    /**
+     * Visitor design pattern
+     * @param {Object} thing - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @protected
+     */
+    protected visit(thing: any, parameters: any): any;
+    /**
+     * Visitor design pattern
+     * @param {ModelManager} modelManager - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitModelManager(modelManager: ModelManager, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ModelFile} modelFile - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitModelFile(modelFile: ModelFile, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitAssetDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitEnumDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitEventDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitParticipantDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitTransactionDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {ClassDeclaration} classDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @param {string} type  - the type of the declaration
+     * @protected
+     */
+    protected visitClassDeclaration(classDeclaration: ClassDeclaration, parameters: any, type?: string): void;
+    /**
+     * Visitor design pattern
+     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitScalarDeclaration(scalarDeclaration: ScalarDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitMapDeclaration(mapDeclaration: MapDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitScalarField(field: Field, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {RelationshipDeclaration} relationship - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitRelationship(relationship: RelationshipDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitField(field: Field, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitEnumValueDeclaration(enumValueDeclaration: EnumValueDeclaration, parameters: any): void;
+    /**
+     * Visitor design pattern
+     * @param {Decorator} decorator - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @protected
+     */
+    protected visitDecorator(decorator: Decorator, parameters: any): void;
+}
+import { ModelManager } from "@accordproject/concerto-core";
+import { ModelFile } from "@accordproject/concerto-core";
+import { ClassDeclaration } from "@accordproject/concerto-core";
+import { ScalarDeclaration } from "@accordproject/concerto-core";
+import { Field } from "@accordproject/concerto-core";
+import { RelationshipDeclaration } from "@accordproject/concerto-core";
+import { EnumValueDeclaration } from "@accordproject/concerto-core";
+import { Decorator } from "@accordproject/concerto-core";

--- a/types/lib/common/diagramvisitor.d.ts
+++ b/types/lib/common/diagramvisitor.d.ts
@@ -7,121 +7,7 @@ export = DiagramVisitor;
  * @protected
  * @class
  */
-declare class DiagramVisitor {
-    /**
-     * Visitor design pattern
-     * @param {Object} thing - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @return {Object} the result of visiting or null
-     * @protected
-     */
-    protected visit(thing: any, parameters: any): any;
-    /**
-     * Visitor design pattern
-     * @param {ModelManager} modelManager - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitModelManager(modelManager: ModelManager, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ModelFile} modelFile - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitModelFile(modelFile: ModelFile, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitAssetDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitEnumDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitEventDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitParticipantDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitTransactionDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {ClassDeclaration} classDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @param {string} type  - the type of the declaration
-     * @protected
-     */
-    protected visitClassDeclaration(classDeclaration: ClassDeclaration, parameters: any, type?: string): void;
-    /**
-     * Visitor design pattern
-     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitScalarDeclaration(scalarDeclaration: ScalarDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {MapDeclaration} mapDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitMapDeclaration(mapDeclaration: MapDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {Field} field - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitScalarField(field: Field, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {RelationshipDeclaration} relationship - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitRelationship(relationship: RelationshipDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {Field} field - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitField(field: Field, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitEnumValueDeclaration(enumValueDeclaration: EnumValueDeclaration, parameters: any): void;
-    /**
-     * Visitor design pattern
-     * @param {Decorator} decorator - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @protected
-     */
-    protected visitDecorator(decorator: Decorator, parameters: any): void;
+declare class DiagramVisitor extends BaseVisitor {
     /**
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited
@@ -135,11 +21,5 @@ declare namespace DiagramVisitor {
     let AGGREGATION: string;
     let INHERITANCE: string;
 }
-import { ModelManager } from "@accordproject/concerto-core";
-import { ModelFile } from "@accordproject/concerto-core";
+import BaseVisitor = require("./basevisitor");
 import { ClassDeclaration } from "@accordproject/concerto-core";
-import { ScalarDeclaration } from "@accordproject/concerto-core";
-import { Field } from "@accordproject/concerto-core";
-import { RelationshipDeclaration } from "@accordproject/concerto-core";
-import { EnumValueDeclaration } from "@accordproject/concerto-core";
-import { Decorator } from "@accordproject/concerto-core";

--- a/types/lib/common/graph.d.ts
+++ b/types/lib/common/graph.d.ts
@@ -11,6 +11,8 @@ export class ConcertoGraphVisitor extends BaseVisitor {
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited
      * @param {Object} parameters  - the parameter
+     * @property {boolean} parameters.includeDerivedTypes - If this option is enabled, edges will be created from super types to their derived types.
+     * This guarantees that if type X exists in the model manager, all types that inherit from X will be represented in the graph.
      * @protected
      */
     protected visitClassDeclaration(classDeclaration: ClassDeclaration, parameters: any): void;

--- a/types/lib/common/graph.d.ts
+++ b/types/lib/common/graph.d.ts
@@ -6,7 +6,7 @@
  * @class
  * @memberof module:concerto-util
  */
-export class ConcertoGraphVisitor extends DiagramVisitor {
+export class ConcertoGraphVisitor extends BaseVisitor {
     /**
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited
@@ -85,7 +85,7 @@ export class DirectedGraph {
      */
     print(writer: Writer): void;
 }
-import DiagramVisitor = require("./diagramvisitor");
+import BaseVisitor = require("./basevisitor");
 import { ClassDeclaration } from "@accordproject/concerto-core";
 import { MapDeclaration } from "@accordproject/concerto-core";
 import { Writer } from "@accordproject/concerto-util";


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
In creating a connected graph, we observe that the relationship between declarations and fields are not reflected as expected. Specifically, when a field has a decorator, the associated decorator is not included in the filtered model manager, leading to an error due to failed decorator validation.

This change add the edge to reflect the relationship between the parent declaration and it's fields.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
