### PR TITLE
fix(visitor): visit decorators before visiting type

### DIFF
--- a/lib/common/basevisitor.js
+++ b/lib/common/basevisitor.js
@@ -194,6 +194,7 @@ class BaseVisitor {
      * @protected
      */
     visitScalarField(field, parameters) {
+        field.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         this.visitField(field.getScalarField(), parameters);
     }
 
@@ -204,6 +205,7 @@ class BaseVisitor {
      * @protected
      */
     visitRelationship(relationship, parameters) {
+        relationship.getDecorators().forEach(decorator => decorator.accept(this, parameters));
         this.visitField(relationship, parameters);
     }
 


### PR DESCRIPTION
Fixes an issue with visitors where the decorators of scalar fields and relationships where not visited.

### Changes
Visit the decorators of scalar fields and relationships before visiting their types

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
