### PR TITLE
feat: implement rustdoc comment generation support

### DIFF
--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -304,6 +304,7 @@ class RustVisitor {
      * @private
      */
     visitClassDeclaration(classDeclaration, parameters) {
+        this.writeDescription(classDeclaration, parameters, 0);
         parameters.fileWriter.writeLine(
             0,
             '#[derive(Debug, Clone, Serialize, Deserialize)]'
@@ -513,6 +514,8 @@ class RustVisitor {
             if (field.isOptional?.()) {
                 hashMapType = this.wrapAsOption(hashMapType);
             }
+            // Add description for HashMap fields
+            this.writeDescription(field, parameters, 1);
 
             // Generate serde attributes for HashMap with DateTime serialization support
             parameters.fileWriter.writeLine(1, '#[serde(');
@@ -607,6 +610,10 @@ class RustVisitor {
         }
 
         // Handle regular (non-HashMap) fields
+
+        // Add description for regular fields
+        this.writeDescription(field, parameters, 1);
+
         parameters.fileWriter.writeLine(1, '#[serde(');
         parameters.fileWriter.writeLine(2, `rename = "${field.name}",`);
         if (field.isOptional?.()) {
@@ -752,6 +759,7 @@ class RustVisitor {
         if (relationshipDeclaration.isOptional?.()) {
             type = `Option<${type}>`;
         }
+        this.writeDescription(relationshipDeclaration, parameters, 1);
 
         // Start serde attribute block
         parameters.fileWriter.writeLine(1, '#[serde(');
@@ -1326,6 +1334,24 @@ class RustVisitor {
         parameters.fileWriter.writeLine(0, '}');
 
         parameters.fileWriter.closeFile();
+    }
+    /**
+     * Writes the description of a declaration or property as a Rust documentation comment.
+     * @param {Object} thing - the declaration or property
+     * @param {Object} parameters - the parameters
+     * @param {number} indent - the indentation level
+     * @private
+     */
+    writeDescription(thing, parameters, indent) {
+        if (thing.getDescription && thing.getDescription()) {
+            const description = thing.getDescription();
+            // Split by newline to handle multi-line comments cleanly
+            const lines = description.split(/\r?\n/);
+            lines.forEach(line => {
+                // Write '/// ' followed by the trimmed line
+                parameters.fileWriter.writeLine(indent, `/// ${line.trim()}`);
+            });
+        }
     }
 }
 

--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -1348,8 +1348,15 @@ class RustVisitor {
             // Split by newline to handle multi-line comments cleanly
             const lines = description.split(/\r?\n/);
             lines.forEach(line => {
-                // Write '/// ' followed by the trimmed line
-                parameters.fileWriter.writeLine(indent, `/// ${line.trim()}`);
+                // Preserve leading whitespace (important for Markdown),
+                // but trim trailing whitespace. For blank lines, emit
+                // "///" without a trailing space.
+                const trimmedEnd = line.replace(/\s+$/, '');
+                if (trimmedEnd === '') {
+                    parameters.fileWriter.writeLine(indent, '///');
+                } else {
+                    parameters.fileWriter.writeLine(indent, `/// ${trimmedEnd}`);
+                }
             });
         }
     }


### PR DESCRIPTION
## Description
This PR brings the Rust generator closer to feature parity by adding support for documentation comments. It implements a `writeDescription` helper method that converts Concerto model descriptions into standard Rust documentation comments (`///`).

## Changes
* Added `writeDescription` helper method to `RustVisitor` class.
* Updated `visitClassDeclaration` to generate documentation for Structs and Enums.
* Updated `visitField` to generate documentation for Fields (including HashMap support).
* Updated `visitRelationshipDeclaration` to generate documentation for Relationships.

## Testing & Verification
I verified this logic locally using a debug script.

**Note on Upstream Parser Behavior:**
I discovered that the current version of `@accordproject/concerto-cto` (v3.25.0) used in this repository appears to strip comments during AST parsing. As a result, `thing.getDescription()` returns `undefined` by default when parsing a string.

To verify that my `RustVisitor` logic works correctly, I used a script that manually injects descriptions into the `ClassDeclaration` objects in memory after parsing. This confirmed that the generator correctly formats and outputs the RustDoc comments when the data is present in the model.

### Verification Script (`debug-rust.js`)
```javascript
const { ModelManager, ModelFile } = require('@accordproject/concerto-core');
const { Parser } = require('@accordproject/concerto-cto');
const { CodeGen } = require('./index');
const FileWriter = require('@accordproject/concerto-util').FileWriter;

const cto = `namespace com.test
asset Car identified by vin {
  o String vin
  o String color
}`;

// 1. Setup
const modelManager = new ModelManager();
const ast = Parser.parse(cto);
const modelFile = new ModelFile(modelManager, ast, 'test.cto');
modelManager.addModelFile(modelFile);

// 2. Manual Injection (Simulating a working parser)
const carDecl = modelFile.getType('com.test.Car');
if (carDecl) {
    carDecl.getDescription = () => "Documentation for Car Class";
    
    const colorField = carDecl.getProperty('color');
    if (colorField) {
        colorField.getDescription = () => "Documentation for Color Field";
    }
}

// 3. Run Visitor
const visitor = new CodeGen.RustVisitor();
const parameters = { fileWriter: new FileWriter('./output') };

modelManager.accept(visitor, parameters);
```

here is the debug script output which I got, after the modifications I made to rustvisitor.js:
<img width="1920" height="1080" alt="Screenshot" src="https://github.com/user-attachments/assets/9b7cb136-7e22-4ed4-b473-0820d8c3ce23" />
Line 7 shows that the comment has been injected.

I am uploading the two files, `debug-rust.js`  here:
[debug-rust.js](https://github.com/user-attachments/files/24580653/debug-rust.js)

