### PR TITLE
feat(jsonschema): add includeTypeTag and defaultsAreOptional options

### DIFF
--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -34,6 +34,18 @@ const RecursionDetectionVisitor = require('./recursionvisitor');
  * The default value for refRoot is '#/definitions'. Set the refRoot parameter
  * to override.
  *
+ * Set `includeTypeTag` to `false` to suppress the `$class` property that is
+ * otherwise emitted on every object schema (both as a property and in
+ * `required`). Useful for consumers that do not round-trip Concerto types —
+ * e.g. downstream validators that only see plain JSON data.
+ *
+ * Set `defaultsAreOptional` to `true` to exclude properties that declare a
+ * `default=value` from the generated `required` array. Useful when the
+ * caller's input may legitimately omit fields that the model provides a
+ * default for. Applies to both class properties and the `$class` tag.
+ *
+ * Both options default to `false` (preserving historical behavior).
+ *
  * The meta schema used is http://json-schema.org/draft-07/schema#
  *
  * @private
@@ -310,15 +322,23 @@ class JSONSchemaVisitor {
                 required: []
             }};
 
-        // Every class declaration has a $class property.
-        result.schema.properties.$class = {
-            type: 'string',
-            default: classDeclaration.getFullyQualifiedName(),
-            pattern: `^${classDeclaration.getFullyQualifiedName().split('.').join('\\.')}$`,
-            description: `The class identifier for ${classDeclaration.getFullyQualifiedName()}`
-        };
+        // Every class declaration has a $class property, unless the caller
+        // has opted out via `includeTypeTag: false`.
+        if (parameters.includeTypeTag !== false) {
+            result.schema.properties.$class = {
+                type: 'string',
+                default: classDeclaration.getFullyQualifiedName(),
+                pattern: `^${classDeclaration.getFullyQualifiedName().split('.').join('\\.')}$`,
+                description: `The class identifier for ${classDeclaration.getFullyQualifiedName()}`
+            };
 
-        result.schema.required.push('$class');
+            // $class always carries a default (the FQN), so it is excluded
+            // from `required` when the caller has opted into treating
+            // defaults as optional.
+            if (!parameters.defaultsAreOptional) {
+                result.schema.required.push('$class');
+            }
+        }
 
         // Walk over all of the properties of this class and its super classes.
         classDeclaration.getProperties().forEach((property) => {
@@ -331,6 +351,15 @@ class JSONSchemaVisitor {
 
             // If the property is required, add it to the list.
             if (!property.isOptional()) {
+                // When the caller has opted in via `defaultsAreOptional: true`,
+                // properties that declare a default value are treated as
+                // optional in the JSON Schema even if they are non-optional
+                // in the Concerto model.
+                const hasDefault = property.getDefaultValue?.() !== null &&
+                    property.getDefaultValue?.() !== undefined;
+                if (parameters.defaultsAreOptional && hasDefault) {
+                    return;
+                }
                 result.schema.required.push(property.getName());
             }
         });

--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -355,8 +355,9 @@ class JSONSchemaVisitor {
                 // properties that declare a default value are treated as
                 // optional in the JSON Schema even if they are non-optional
                 // in the Concerto model.
-                const hasDefault = property.getDefaultValue?.() !== null &&
-                    property.getDefaultValue?.() !== undefined;
+                const defaultValue = property.getDefaultValue?.();
+                const hasDefault = defaultValue !== null &&
+                    defaultValue !== undefined;
                 if (parameters.defaultsAreOptional && hasDefault) {
                     return;
                 }

--- a/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -550,4 +550,116 @@ describe('JSONSchema (samples)', function () {
             expect( ajv.validate(schema, instance)).equals(true);
         });
     });
+
+    describe('options', () => {
+        const MODEL_WITH_DEFAULTS = `
+namespace test.options
+
+concept Account {
+  o String name
+  o String currency default="USD"
+  o Integer balance default=0
+  o Boolean active default=true
+}
+`;
+
+        it('emits $class by default (backward compatible)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, { rootType: 'test.options.Account' });
+            expect(schema.properties.$class).to.not.be.undefined;
+            expect(schema.properties.$class.type).to.equal('string');
+            expect(schema.required).to.include('$class');
+        });
+
+        it('suppresses $class property and its required entry when includeTypeTag is false', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test.options.Account',
+                includeTypeTag: false,
+            });
+            expect(schema.properties.$class).to.be.undefined;
+            expect(schema.required).to.not.include('$class');
+            // other fields still present and required as usual
+            expect(schema.properties.name).to.not.be.undefined;
+            expect(schema.required).to.include('name');
+        });
+
+        it('still includes $class when includeTypeTag is true (explicit default)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test.options.Account',
+                includeTypeTag: true,
+            });
+            expect(schema.properties.$class).to.not.be.undefined;
+            expect(schema.required).to.include('$class');
+        });
+
+        it('marks defaulted properties as required by default (backward compatible)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, { rootType: 'test.options.Account' });
+            expect(schema.required).to.include('name');
+            expect(schema.required).to.include('currency');
+            expect(schema.required).to.include('balance');
+            expect(schema.required).to.include('active');
+        });
+
+        it('excludes defaulted properties from required when defaultsAreOptional is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test.options.Account',
+                defaultsAreOptional: true,
+            });
+            // `name` has no default, stays required
+            expect(schema.required).to.include('name');
+            // `currency`, `balance`, `active` all have defaults, move off required
+            expect(schema.required).to.not.include('currency');
+            expect(schema.required).to.not.include('balance');
+            expect(schema.required).to.not.include('active');
+            // the properties themselves still exist
+            expect(schema.properties.currency.default).to.equal('USD');
+            expect(schema.properties.balance.default).to.equal(0);
+            expect(schema.properties.active.default).to.equal(true);
+        });
+
+        it('excludes $class from required when defaultsAreOptional is true (since $class carries an implicit default)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test.options.Account',
+                defaultsAreOptional: true,
+            });
+            // $class property still emitted (includeTypeTag untouched)
+            expect(schema.properties.$class).to.not.be.undefined;
+            // but no longer in required, since its default is the FQN itself
+            expect(schema.required).to.not.include('$class');
+        });
+
+        it('honors both options together', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test.options.Account',
+                includeTypeTag: false,
+                defaultsAreOptional: true,
+            });
+            expect(schema.properties.$class).to.be.undefined;
+            expect(schema.required).to.not.include('$class');
+            expect(schema.required).to.include('name');
+            expect(schema.required).to.not.include('currency');
+            expect(schema.required).to.not.include('balance');
+            expect(schema.required).to.not.include('active');
+        });
+    });
 });

--- a/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -553,7 +553,7 @@ describe('JSONSchema (samples)', function () {
 
     describe('options', () => {
         const MODEL_WITH_DEFAULTS = `
-namespace test.options
+namespace test.options@1.0.0
 
 concept Account {
   o String name
@@ -567,7 +567,7 @@ concept Account {
             const modelManager = new ModelManager();
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
-            const schema = modelManager.accept(visitor, { rootType: 'test.options.Account' });
+            const schema = modelManager.accept(visitor, { rootType: 'test.options@1.0.0.Account' });
             expect(schema.properties.$class).to.not.be.undefined;
             expect(schema.properties.$class.type).to.equal('string');
             expect(schema.required).to.include('$class');
@@ -578,7 +578,7 @@ concept Account {
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {
-                rootType: 'test.options.Account',
+                rootType: 'test.options@1.0.0.Account',
                 includeTypeTag: false,
             });
             expect(schema.properties.$class).to.be.undefined;
@@ -593,7 +593,7 @@ concept Account {
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {
-                rootType: 'test.options.Account',
+                rootType: 'test.options@1.0.0.Account',
                 includeTypeTag: true,
             });
             expect(schema.properties.$class).to.not.be.undefined;
@@ -604,7 +604,7 @@ concept Account {
             const modelManager = new ModelManager();
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
-            const schema = modelManager.accept(visitor, { rootType: 'test.options.Account' });
+            const schema = modelManager.accept(visitor, { rootType: 'test.options@1.0.0.Account' });
             expect(schema.required).to.include('name');
             expect(schema.required).to.include('currency');
             expect(schema.required).to.include('balance');
@@ -616,7 +616,7 @@ concept Account {
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {
-                rootType: 'test.options.Account',
+                rootType: 'test.options@1.0.0.Account',
                 defaultsAreOptional: true,
             });
             // `name` has no default, stays required
@@ -636,7 +636,7 @@ concept Account {
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {
-                rootType: 'test.options.Account',
+                rootType: 'test.options@1.0.0.Account',
                 defaultsAreOptional: true,
             });
             // $class property still emitted (includeTypeTag untouched)
@@ -650,7 +650,7 @@ concept Account {
             modelManager.addCTOModel(MODEL_WITH_DEFAULTS);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {
-                rootType: 'test.options.Account',
+                rootType: 'test.options@1.0.0.Account',
                 includeTypeTag: false,
                 defaultsAreOptional: true,
             });


### PR DESCRIPTION
## Summary

Adds two additive, opt-in parameters to `JSONSchemaVisitor` that let downstream consumers suppress the `$class` type tag and/or treat defaulted Concerto properties as optional in the generated JSON Schema. Both parameters default to today's behavior, so no existing consumer sees a change.

```js
// historical behavior — unchanged
modelManager.accept(visitor, { rootType: 'my.Model' });

// new: skip $class everywhere
modelManager.accept(visitor, { rootType: 'my.Model', includeTypeTag: false });

// new: defaulted fields drop out of required[]
modelManager.accept(visitor, { rootType: 'my.Model', defaultsAreOptional: true });
```

## Why

`JSONSchemaVisitor` is helpful for round-tripping Concerto instances, but it's also widely used as a plain JSON Schema source for validation of data that never carries a Concerto `$class` tag and that legitimately omits fields that the model provides a default for. Those consumers currently post-process the generated schema after codegen — filtering `$class` out of `properties` and `required`, and filtering defaulted fields out of `required`. Both of those patches are mechanical and context-free; a codegen option is the cleaner home for them.

Concrete motivating case: contract-template generators that feed the output schema to `jsonschema.Draft7Validator` in Python against request payloads produced by upstream agents (which don't carry `$class` and may omit defaulted fields). Those projects today run a JS post-processor after `cicero-codegen` and would delete that entire step once these options land.

## What changed

### `lib/codegen/fromcto/jsonschema/jsonschemavisitor.js`

- `visitClassDeclarationCommon` gates the `$class` property addition and its `required` entry on `parameters.includeTypeTag !== false`. Default: `$class` emitted (today's behavior).
- In the property loop, `required.push(property.getName())` is skipped when `parameters.defaultsAreOptional` is true AND the property has a non-null default value. Default: defaulted properties still go into `required` (today's behavior).
- `$class` is excluded from `required` under `defaultsAreOptional: true` because its implicit default is the FQN itself — matching the user-property semantics.
- Class-level JSDoc describes both new options.

### `test/codegen/fromcto/jsonschema/jsonschemavisitor.js`

- New `options` describe block with 7 test cases:
  - backward-compatible `$class` emission (no options)
  - `includeTypeTag: false` suppresses `$class` in both `properties` and `required`
  - `includeTypeTag: true` (explicit default) matches historical behavior
  - defaulted fields appear in `required` by default
  - `defaultsAreOptional: true` removes defaulted user fields from `required`
  - `defaultsAreOptional: true` also removes `$class` from `required` (since `$class` has an implicit default)
  - both options honored together

## Test plan

- [x] `npm test` — 576 passing, 0 failures, 0 regressions (was 569 baseline). Coverage 99.3% statements, 96.49% branches.
- [x] `npm run lint` — clean.
- [x] Manually verified with a small model containing `default=` fields that existing consumers (no options passed) get byte-identical schemas.
- [x] Manually verified `defaultsAreOptional: true` drops `$class` and defaulted properties from `required` while keeping the property definitions (including their `default` values) in `properties`.

## Out of scope

- String-valued enum support (e.g. arbitrary-character enum values). That's a separate, larger conversation for `accordproject/concerto` rather than `concerto-codegen`.
- Similar options on other visitors (TypeScript, C#, Go, …). Happy to follow up if this is accepted and the pattern generalizes.

Signed-off-by: Yuzhou Wang <wusiwyzb5@gmail.com>
