### PR TITLE
chore(*): revert protobuf test to use model fromURI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "pluralize": "8.0.0"
             },
             "devDependencies": {
-                "@accordproject/concerto-cto": "4.0.1",
+                "@accordproject/concerto-cto": "4.0.2",
                 "@babel/preset-env": "7.16.11",
                 "@types/webgl-ext": "0.0.37",
                 "babel-loader": "8.2.3",
@@ -53,164 +53,21 @@
                 "npm": ">=6"
             },
             "peerDependencies": {
-                "@accordproject/concerto-core": "^4.0.1",
-                "@accordproject/concerto-util": "^4.0.1",
-                "@accordproject/concerto-vocabulary": "^4.0.1"
+                "@accordproject/concerto-core": "^4.0.2",
+                "@accordproject/concerto-util": "^4.0.2",
+                "@accordproject/concerto-vocabulary": "^4.0.2"
             }
-        },
-        "node_modules/@accordproject/concerto-codegen": {
-            "version": "3.32.1",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-3.32.1.tgz",
-            "integrity": "sha512-nVFCTUk/i37dm5zdfteZtCf/okinVFEX/+V6lO3Jsc7NIWrU9CPP8KAqhG1nB+3Rsqmg3qt7BQT0xe5dMyFnHQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-core": "3.25.0",
-                "@accordproject/concerto-util": "3.25.0",
-                "@accordproject/concerto-vocabulary": "3.25.0",
-                "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
-                "ajv": "8.18.0",
-                "ajv-formats": "3.0.1",
-                "camelcase": "6.3.0",
-                "debug": "4.3.4",
-                "get-value": "3.0.1",
-                "json-schema-migrate": "2.0.0",
-                "pluralize": "8.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core": {
-            "version": "3.25.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.0.tgz",
-            "integrity": "sha512-A/Zr4bFTYjWkVEVZCvQadLk08sT5oAx3ED/674lq89vC6Ml/mwopym8JKKszIF5oq8TOMzLhRrxpdLfI3rIQSg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-cto": "3.25.0",
-                "@accordproject/concerto-metamodel": "3.12.6",
-                "@accordproject/concerto-util": "3.25.0",
-                "dayjs": "1.11.13",
-                "debug": "4.3.7",
-                "lorem-ipsum": "2.0.8",
-                "randexp": "0.5.3",
-                "rfdc": "1.4.1",
-                "semver": "7.6.3",
-                "urijs": "1.19.11",
-                "uuid": "11.0.3",
-                "yaml": "^2.8.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-cto": {
-            "version": "3.25.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.0.tgz",
-            "integrity": "sha512-WVPyHYBEg1vwVCH6lOu+7BfNSeRuuV/Tli5CLZI9NPCcI2i/QWWBm6aEs02KnNiC++YTpGK6huvL6n6rz/0Wmg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-metamodel": "3.12.6",
-                "@accordproject/concerto-util": "3.25.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util": {
-            "version": "3.25.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.0.tgz",
-            "integrity": "sha512-TNUcM+Tb+J26K6FZDC44WOUt1S7e17fn6oVe4UaYpaZPY4kg64YbHg1sUkIioiDFtamOMoJDyBeKoPLMi1BDOQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-vocabulary": {
-            "version": "3.25.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-3.25.0.tgz",
-            "integrity": "sha512-WrnSMSQAFuJhFpH6h+4oN1UOcBbZEl8zXpugkHUYG5EMeQWu41g1M3OAqYzr8oVQV7bUEH05EDcgBClzAUJuPQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-metamodel": "3.12.6",
-                "yaml": "2.6.1"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-vocabulary/node_modules/yaml": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@accordproject/concerto-codegen/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
         },
         "node_modules/@accordproject/concerto-core": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.0.1.tgz",
-            "integrity": "sha512-LiLQ1iU+xcRI2oqKhOFOv8Gff1N/TjKEs3tEXABo+I67Fdqgm7gbmwv3FJsE+Tz/sksfBaL70V7/5az5gyu2Hg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.0.2.tgz",
+            "integrity": "sha512-lf4CBmzrtCRFui3Kn/msv6MXAb3D2PoZl5kkRtve0U5hAhhxO6ZZYZgARvBIWkMy0wJM6tiqbHu1uZbOEgWCMQ==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@accordproject/concerto-codegen": "^3.16.2",
-                "@accordproject/concerto-cto": "4.0.1",
+                "@accordproject/concerto-cto": "4.0.2",
                 "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
-                "@accordproject/concerto-util": "4.0.1",
+                "@accordproject/concerto-util": "4.0.2",
                 "debug": "4.3.7",
                 "lorem-ipsum": "2.0.8",
                 "randexp": "0.5.3",
@@ -223,115 +80,6 @@
             "engines": {
                 "node": ">=18",
                 "npm": ">=9"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.24.0.tgz",
-            "integrity": "sha512-JrrBw3JMwtogiYPjBaRV6CZCKi2hXIdOVzyFslshfBMe3dkm94iloW8ASr3tsnWMfjuDUinsTksX/wfHJ9DXgA==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@accordproject/concerto-cto": "3.24.0",
-                "@accordproject/concerto-metamodel": "^3.12.4",
-                "@accordproject/concerto-util": "3.24.0",
-                "dayjs": "1.11.13",
-                "debug": "4.3.7",
-                "lorem-ipsum": "2.0.8",
-                "randexp": "0.5.3",
-                "rfdc": "1.4.1",
-                "semver": "7.6.3",
-                "urijs": "1.19.11",
-                "uuid": "11.0.3",
-                "yaml": "^2.8.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.24.0.tgz",
-            "integrity": "sha512-DCTdUE3qExe3CCkg3PO1yBhj0/CGqY5al+kLkQuZ3p/MfFRZWkWMNdox6g7S9VtednRb5NPhkrLwlNRpJbkcmA==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@accordproject/concerto-metamodel": "3.12.4",
-                "@accordproject/concerto-util": "3.24.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.4",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
-            "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.9",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.9.tgz",
-            "integrity": "sha512-VKkJIcl2d7Fvkp6F9XDMy3oKvLxFJMYpTOKYaYXl+C7DSjnBl+T74DC0Vr9EOzCs/UQ2JNRqJJ20b9pN48patg==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
-            "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-            "version": "4.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-4.0.0-alpha.0.tgz",
-            "integrity": "sha512-JYSBk4NA6P41MjJCVe4WrA1QW1iTJ2Bfkd1f8EcfnhfuCtH+rmQItoTV8X1pb/+ql+3gVMfitaE1klKiUMMJGw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@accordproject/concerto-core": "3.24.0",
-                "@accordproject/concerto-util": "3.24.0"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
-            "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
             }
         },
         "node_modules/@accordproject/concerto-core/node_modules/debug": {
@@ -360,14 +108,13 @@
             "peer": true
         },
         "node_modules/@accordproject/concerto-cto": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.0.1.tgz",
-            "integrity": "sha512-D2k6mnT7x4A0WZ4mDO8TbbZ3n2NmQV7Z9ZRM3mEBHbqutm0ypUHqDnalZIAcL2Z3FFEm5wIbqlgKuOD8LnLvcQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.0.2.tgz",
+            "integrity": "sha512-eti55jb8z8dv5X5ZQH4CYJhdMMUYFyRGIcRDVPwIO6KxnquZ0bEor47d4B6nB2GkE0IhLkfel/AOPQfhdD+0mQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@accordproject/concerto-codegen": "^3.16.2",
                 "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
-                "@accordproject/concerto-util": "4.0.1",
+                "@accordproject/concerto-util": "4.0.2",
                 "acorn": "^8.15.0",
                 "path-browserify": "^1.0.1",
                 "schema-utils": "^4.3.3"
@@ -375,123 +122,6 @@
             "engines": {
                 "node": ">=18",
                 "npm": ">=9"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-core": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.24.0.tgz",
-            "integrity": "sha512-JrrBw3JMwtogiYPjBaRV6CZCKi2hXIdOVzyFslshfBMe3dkm94iloW8ASr3tsnWMfjuDUinsTksX/wfHJ9DXgA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-cto": "3.24.0",
-                "@accordproject/concerto-metamodel": "^3.12.4",
-                "@accordproject/concerto-util": "3.24.0",
-                "dayjs": "1.11.13",
-                "debug": "4.3.7",
-                "lorem-ipsum": "2.0.8",
-                "randexp": "0.5.3",
-                "rfdc": "1.4.1",
-                "semver": "7.6.3",
-                "urijs": "1.19.11",
-                "uuid": "11.0.3",
-                "yaml": "^2.8.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.9",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.9.tgz",
-            "integrity": "sha512-VKkJIcl2d7Fvkp6F9XDMy3oKvLxFJMYpTOKYaYXl+C7DSjnBl+T74DC0Vr9EOzCs/UQ2JNRqJJ20b9pN48patg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
-            "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-cto": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.24.0.tgz",
-            "integrity": "sha512-DCTdUE3qExe3CCkg3PO1yBhj0/CGqY5al+kLkQuZ3p/MfFRZWkWMNdox6g7S9VtednRb5NPhkrLwlNRpJbkcmA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-metamodel": "3.12.4",
-                "@accordproject/concerto-util": "3.24.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.4",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
-            "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-util": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
-            "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-            "version": "4.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-4.0.0-alpha.0.tgz",
-            "integrity": "sha512-JYSBk4NA6P41MjJCVe4WrA1QW1iTJ2Bfkd1f8EcfnhfuCtH+rmQItoTV8X1pb/+ql+3gVMfitaE1klKiUMMJGw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-core": "3.24.0",
-                "@accordproject/concerto-util": "3.24.0"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-            "version": "3.24.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
-            "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@supercharge/promise-pool": "1.7.0",
-                "debug": "4.3.7",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=10"
             }
         },
         "node_modules/@accordproject/concerto-cto/node_modules/ajv-formats": {
@@ -510,29 +140,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@accordproject/concerto-cto/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
         },
         "node_modules/@accordproject/concerto-cto/node_modules/schema-utils": {
             "version": "4.3.3",
@@ -554,54 +161,24 @@
             }
         },
         "node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.6",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-            "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+            "version": "4.0.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-4.0.0-alpha.0.tgz",
+            "integrity": "sha512-JYSBk4NA6P41MjJCVe4WrA1QW1iTJ2Bfkd1f8EcfnhfuCtH+rmQItoTV8X1pb/+ql+3gVMfitaE1klKiUMMJGw==",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@accordproject/concerto-core": "3.24.0",
+                "@accordproject/concerto-util": "3.24.0"
+            },
             "engines": {
                 "node": ">=14",
                 "npm": ">=6"
             }
         },
-        "node_modules/@accordproject/concerto-util": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.0.1.tgz",
-            "integrity": "sha512-78pV6fZip8NzVY69388HblDS0sTrHky8Y2Kr7kNLoGn7iJ0AwY+RdcCFuo1+Zr2FCueYz1o7wRKVRS6yZqzcRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@accordproject/concerto-codegen": "^3.16.2",
-                "@supercharge/promise-pool": "1.7.0",
-                "colors": "1.4.0",
-                "debug": "4.3.4",
-                "slash": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=9"
-            }
-        },
-        "node_modules/@accordproject/concerto-vocabulary": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.0.1.tgz",
-            "integrity": "sha512-njhiuKbWDarO7G2KvCtkq59CTaoll1m9aoyEDV+WGBruSIQLNnGeWhxXRJXy74diycpH7uA7hAUf7c5HYq6KNw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@accordproject/concerto-codegen": "^3.16.2",
-                "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
-                "yaml": "2.8.3"
-            },
-            "engines": {
-                "node": ">=18",
-                "npm": ">=9"
-            }
-        },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-core": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-core": {
             "version": "3.24.0",
             "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.24.0.tgz",
             "integrity": "sha512-JrrBw3JMwtogiYPjBaRV6CZCKi2hXIdOVzyFslshfBMe3dkm94iloW8ASr3tsnWMfjuDUinsTksX/wfHJ9DXgA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@accordproject/concerto-cto": "3.24.0",
                 "@accordproject/concerto-metamodel": "^3.12.4",
@@ -621,23 +198,11 @@
                 "npm": ">=10"
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-            "version": "3.12.9",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.9.tgz",
-            "integrity": "sha512-VKkJIcl2d7Fvkp6F9XDMy3oKvLxFJMYpTOKYaYXl+C7DSjnBl+T74DC0Vr9EOzCs/UQ2JNRqJJ20b9pN48patg==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-cto": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-cto": {
             "version": "3.24.0",
             "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.24.0.tgz",
             "integrity": "sha512-DCTdUE3qExe3CCkg3PO1yBhj0/CGqY5al+kLkQuZ3p/MfFRZWkWMNdox6g7S9VtednRb5NPhkrLwlNRpJbkcmA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@accordproject/concerto-metamodel": "3.12.4",
                 "@accordproject/concerto-util": "3.24.0"
@@ -647,38 +212,31 @@
                 "npm": ">=10"
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
             "version": "3.12.4",
             "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
             "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=14",
                 "npm": ">=6"
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-metamodel": {
-            "version": "4.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-4.0.0-alpha.0.tgz",
-            "integrity": "sha512-JYSBk4NA6P41MjJCVe4WrA1QW1iTJ2Bfkd1f8EcfnhfuCtH+rmQItoTV8X1pb/+ql+3gVMfitaE1klKiUMMJGw==",
+        "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-metamodel": {
+            "version": "3.12.9",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.9.tgz",
+            "integrity": "sha512-VKkJIcl2d7Fvkp6F9XDMy3oKvLxFJMYpTOKYaYXl+C7DSjnBl+T74DC0Vr9EOzCs/UQ2JNRqJJ20b9pN48patg==",
             "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@accordproject/concerto-core": "3.24.0",
-                "@accordproject/concerto-util": "3.24.0"
-            },
             "engines": {
                 "node": ">=14",
                 "npm": ">=6"
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-util": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
             "version": "3.24.0",
             "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
             "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@supercharge/promise-pool": "1.7.0",
                 "debug": "4.3.7",
@@ -689,12 +247,11 @@
                 "npm": ">=10"
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/debug": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/debug": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -707,12 +264,42 @@
                 }
             }
         },
-        "node_modules/@accordproject/concerto-vocabulary/node_modules/ms": {
+        "node_modules/@accordproject/concerto-metamodel/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
+        },
+        "node_modules/@accordproject/concerto-util": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.0.2.tgz",
+            "integrity": "sha512-VVItQqEL0dh/URfZYDPCJz+wCQxhHZydS1wVcujsW9rNM7Fe+b3MaZK5kXuz3u7aj75mUxxOV1lPDV55UWeqjw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@supercharge/promise-pool": "1.7.0",
+                "colors": "1.4.0",
+                "debug": "4.3.4",
+                "slash": "3.0.0"
+            },
+            "engines": {
+                "node": ">=18",
+                "npm": ">=9"
+            }
+        },
+        "node_modules/@accordproject/concerto-vocabulary": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.0.2.tgz",
+            "integrity": "sha512-E8MhUPPVmPBIPlvwFE/kGpBXVcms8RRtcnCQwF5HGMSksC2W19HBfx4YCgNTn4xhkx0tuNL84dcTFrfTysiDGQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
+                "yaml": "2.8.3"
+            },
+            "engines": {
+                "node": ">=18",
+                "npm": ">=9"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "author": "accordproject.org",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@accordproject/concerto-cto": "4.0.1",
+        "@accordproject/concerto-cto": "4.0.2",
         "@babel/preset-env": "7.16.11",
         "@types/webgl-ext": "0.0.37",
         "babel-loader": "8.2.3",
@@ -88,9 +88,9 @@
         "pluralize": "8.0.0"
     },
     "peerDependencies": {
-        "@accordproject/concerto-core": "^4.0.1",
-        "@accordproject/concerto-util": "^4.0.1",
-        "@accordproject/concerto-vocabulary": "^4.0.1"
+        "@accordproject/concerto-core": "^4.0.2",
+        "@accordproject/concerto-util": "^4.0.2",
+        "@accordproject/concerto-vocabulary": "^4.0.2"
     },
     "license-check-and-add-config": {
         "folder": "./lib",

--- a/test/codegen/fromcto/protobuf/data/apapProtocol.cto
+++ b/test/codegen/fromcto/protobuf/data/apapProtocol.cto
@@ -1,9 +1,9 @@
 @description("Accord Project Agreement Protocol")
 namespace org.accordproject.protocol@1.0.0
 
-import concerto.metamodel@1.0.0.{Property,ConceptDeclaration,Model}
-import org.accordproject.commonmark@0.5.0.Document
-import org.accordproject.party@0.2.0.{Party}
+import concerto.metamodel@0.4.0.{Property,ConceptDeclaration,Model} from https://models.accordproject.org/concerto/metamodel@0.4.0.cto
+import org.accordproject.commonmark@0.5.0.Document from https://models.accordproject.org/markdown/commonmark@0.5.0.cto
+import org.accordproject.party@0.2.0.{Party} from https://models.accordproject.org/accordproject/party@0.2.0.cto
 
 scalar JSON extends String
 scalar FullyQualifiedTypeName extends String

--- a/test/codegen/fromcto/protobuf/data/org.accordproject.protocol.v1_0_0-expected.proto
+++ b/test/codegen/fromcto/protobuf/data/org.accordproject.protocol.v1_0_0-expected.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package org.accordproject.protocol.v1_0_0;
 
 import "google/protobuf/timestamp.proto";
-import "concerto.metamodel.v1_0_0.proto";
+import "concerto.metamodel.v0_4_0.proto";
 import "org.accordproject.commonmark.v0_5_0.proto";
 import "org.accordproject.party.v0_2_0.proto";
 

--- a/test/codegen/fromcto/protobuf/protobufvisitor.js
+++ b/test/codegen/fromcto/protobuf/protobufvisitor.js
@@ -27,6 +27,7 @@ const ProtobufVisitor = require(
 
 const ModelFile = require('@accordproject/concerto-core').ModelFile;
 const ModelManager = require('@accordproject/concerto-core').ModelManager;
+const ModelLoader = require('@accordproject/concerto-core').ModelLoader;
 const AssetDeclaration = require('@accordproject/concerto-core').AssetDeclaration;
 const ClassDeclaration = require('@accordproject/concerto-core').ClassDeclaration;
 const MapDeclaration = require('@accordproject/concerto-core').MapDeclaration;
@@ -712,39 +713,8 @@ describe('ProtobufVisitor', function () {
     describe('visit CTO file', () => {
         it('should process an APAP protocol CTO file', async () => {
             sandbox.restore();
-            const modelManager = new ModelManager();
-
-            modelManager.addCTOModel(`
-            namespace concerto.metamodel@1.0.0
-
-            concept Property {
-            }
-
-            concept ConceptDeclaration {
-            }
-
-            concept Model {
-            }
-            `, 'metamodel.cto');
-
-            modelManager.addCTOModel(`
-            namespace org.accordproject.commonmark@0.5.0
-
-            concept Document {
-            }
-            `, 'commonmark.cto');
-
-            modelManager.addCTOModel(`
-            namespace org.accordproject.party@0.2.0
-
-            participant Party identified by partyId {
-                o String partyId
-            }
-            `, 'party.cto');
-
-            modelManager.addCTOModel(
-                fs.readFileSync(path.resolve(__dirname, './data/apapProtocol.cto'), 'utf8'),
-                'apapProtocol.cto'
+            const modelManager = await ModelLoader.loadModelManager(
+                [path.resolve(__dirname, './data/apapProtocol.cto')]
             );
             const writer = new InMemoryWriter();
 
@@ -754,6 +724,27 @@ describe('ProtobufVisitor', function () {
                 }
             );
 
+            const expectedMetamodelProtobuf = fs.readFileSync(
+                path.resolve(
+                    __dirname,
+                    './data/concerto.metamodel.v0_4_0-expected.proto'
+                ),
+                'utf8'
+            );
+            const expectedCommonmarkProtobuf = fs.readFileSync(
+                path.resolve(
+                    __dirname,
+                    './data/org.accordproject.commonmark.v0_5_0-expected.proto'
+                ),
+                'utf8'
+            );
+            const expectedApapPartyProtobuf = fs.readFileSync(
+                path.resolve(
+                    __dirname,
+                    './data/org.accordproject.party.v0_2_0-expected.proto'
+                ),
+                'utf8'
+            );
             const expectedApapProtocolProtobuf = fs.readFileSync(
                 path.resolve(
                     __dirname,
@@ -762,57 +753,8 @@ describe('ProtobufVisitor', function () {
                 'utf8'
             );
 
-            const expectedMetamodelProtobuf = [
-                'syntax = "proto3";',
-                '',
-                'package concerto.metamodel.v1_0_0;',
-                '',
-                'import "google/protobuf/timestamp.proto";',
-                '',
-                'message Property {}',
-                '',
-                'message ConceptDeclaration {}',
-                '',
-                'message Model {}',
-                '',
-                ''
-            ].join('\n');
-
-            const expectedCommonmarkProtobuf = [
-                'syntax = "proto3";',
-                '',
-                'package org.accordproject.commonmark.v0_5_0;',
-                '',
-                'import "google/protobuf/timestamp.proto";',
-                '',
-                'message Document {}',
-                '',
-                ''
-            ].join('\n');
-
-            const expectedPartyProtobuf = [
-                'syntax = "proto3";',
-                '',
-                'package org.accordproject.party.v0_2_0;',
-                '',
-                'import "google/protobuf/timestamp.proto";',
-                '',
-                'message Party {',
-                '  string partyId = 1;',
-                '}',
-                '',
-                'message _Subclasses_of_class_Party {',
-                '  oneof _class_oneof_Party {',
-                '    AgreementParty _subclass_of_class_Party_AgreementParty = 1;',
-                '    Party _subclass_of_class_Party_Party = 2;',
-                '  }',
-                '}',
-                '',
-                ''
-            ].join('\n');
-
             assert.equal(
-                writer.data.get('concerto.metamodel.v1_0_0.proto'),
+                writer.data.get('concerto.metamodel.v0_4_0.proto'),
                 expectedMetamodelProtobuf.replace(/\r\n/g, '\n')
             );
 
@@ -823,7 +765,7 @@ describe('ProtobufVisitor', function () {
 
             assert.equal(
                 writer.data.get('org.accordproject.party.v0_2_0.proto'),
-                expectedPartyProtobuf.replace(/\r\n/g, '\n')
+                expectedApapPartyProtobuf.replace(/\r\n/g, '\n')
             );
 
             assert.equal(


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- This reverts the change that made the profobuf test point to a local model rather than load from external registry
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
