### PR TITLE
feat(typescript): emit scalar declarations as type aliases and preserve scalar names in fields and maps

### DIFF
--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -40,6 +40,8 @@ class TypescriptVisitor {
             return this.visitModelManager(thing, parameters);
         } else if (thing.isModelFile?.()) {
             return this.visitModelFile(thing, parameters);
+        } else if (thing.isScalarDeclaration?.()) {
+            return this.visitScalarDeclaration(thing, parameters);
         } else if (thing.isEnum?.()) {
             return this.visitEnumDeclaration(thing, parameters);
         } else if (thing.isClassDeclaration?.()) {
@@ -47,10 +49,7 @@ class TypescriptVisitor {
         } else if (thing.isMapDeclaration?.()) {
             return this.visitMapDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
-            // Propagate optional modifier from the field to visitField via parameters
-            // Avoid mutating the shared scalar descriptor
-            const scalarField = thing.getScalarField();
-            return this.visitField(scalarField, { ...parameters, forceOptional: thing.isOptional() });
+            return this.visitScalarField(thing, parameters);
         } else if (thing.isField?.()) {
             return this.visitField(thing, parameters);
         } else if (thing.isRelationship?.()) {
@@ -123,7 +122,8 @@ class TypescriptVisitor {
                         if (!properties.has(typeNamespace)) {
                             properties.set(typeNamespace, new Set());
                         }
-                        properties.get(typeNamespace).add(property.isTypeEnum?.() ? typeName : `I${typeName}`);
+                        properties.get(typeNamespace).add(
+                            property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
                     }
                 });
 
@@ -169,10 +169,9 @@ class TypescriptVisitor {
 
         parameters.fileWriter.writeLine(0, '\n// interfaces');
         parameters.aliasedTypesMap = aliasedTypesMap;
-        modelFile.getAllDeclarations()
-            .filter(declaration => !declaration.isScalarDeclaration?.()).forEach((decl) => {
-                decl.accept(this, parameters);
-            });
+        modelFile.getAllDeclarations().forEach((decl) => {
+            decl.accept(this, parameters);
+        });
 
         parameters.fileWriter.closeFile();
 
@@ -237,6 +236,19 @@ class TypescriptVisitor {
 
     /**
      * Visitor design pattern
+     * @param {Object} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitScalarDeclaration(scalarDeclaration, parameters) {
+        const tsType = this.toTsType(scalarDeclaration.getType(), false, false);
+        parameters.fileWriter.writeLine(0, `export type ${scalarDeclaration.getName()} = ${tsType};\n`);
+        return null;
+    }
+
+    /**
+     * Visitor design pattern
      * @param {Field} field - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
@@ -288,6 +300,20 @@ class TypescriptVisitor {
     }
 
     /**
+     * Visitor design pattern - handles fields whose type is a scalar declaration
+     * @param {Object} field - the scalar-typed field being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitScalarField(field, parameters) {
+        let array = field.isArray() ? '[]' : '';
+        let optional = field.isOptional() ? '?' : '';
+        parameters.fileWriter.writeLine(1, field.getName() + optional + ': ' + field.getType() + array + ';');
+        return null;
+    }
+
+    /**
      * Visitor design pattern
      * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
      * @param {Object} parameters  - the parameter
@@ -318,20 +344,18 @@ class TypescriptVisitor {
         if (ModelUtil.isPrimitiveType(mapKeyType)) {
             keyType = this.toTsType(mapDeclaration.getKey().getType(), false, false);
         } else if (ModelUtil.isScalar(mapDeclaration.getKey())) {
-            const scalarDeclaration = mapDeclaration.getModelFile().getType(mapDeclaration.getKey().getType());
-            const scalarType = scalarDeclaration.getType();
-            keyType = this.toTsType(scalarType, false, false);
+            keyType = mapKeyType;
         }
 
         // Map Value Type
         if (ModelUtil.isPrimitiveType(mapValueType)) {
             valueType = this.toTsType(mapDeclaration.getValue().getType(), false, false);
         } else if (ModelUtil.isScalar(mapDeclaration.getValue())) {
-            const scalarDeclaration = mapDeclaration.getModelFile().getType(mapDeclaration.getValue().getType());
-            const scalarType = scalarDeclaration.getType();
-            valueType = this.toTsType(scalarType, false, false);
+            valueType = mapValueType;
         } else {
-            valueType = this.toTsType(mapValueType, true, false);
+            const valueDecl = mapDeclaration.getModelFile().getType(mapValueType);
+            const isEnum = valueDecl?.isEnum?.();
+            valueType = this.toTsType(mapValueType, !isEnum, false);
         }
 
         parameters.fileWriter.writeLine(0, 'export type ' + mapDeclaration.getName() + ` = Map<${keyType}, ${valueType}>;\n` );

--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -101,53 +101,73 @@ class TypescriptVisitor {
         });
 
         const properties = new Map();
+        const addImport = (namespace, name) => {
+            if (!properties.has(namespace)) {
+                properties.set(namespace, new Set());
+            }
+            properties.get(namespace).add(name);
+        };
+
         modelFile.getAllDeclarations()
             .filter(declaration => !declaration.isScalarDeclaration?.())
-            .filter(declaration => !declaration.isMapDeclaration?.())
-            .filter(v => !v.isEnum())
-            .forEach(classDeclaration => {
-                if (classDeclaration.getSuperType()) {
-                    const typeNamespace = ModelUtil.getNamespace(classDeclaration.getSuperType());
-                    const typeName = ModelUtil.getShortName(classDeclaration.getSuperType());
-                    if (!properties.has(typeNamespace)) {
-                        properties.set(typeNamespace, new Set());
+            .forEach(declaration => {
+                if (declaration.isMapDeclaration?.()) {
+                    const keyType = declaration.getKey().getType();
+                    const valueType = declaration.getValue().getType();
+
+                    if (!ModelUtil.isPrimitiveType(keyType) && ModelUtil.isScalar(declaration.getKey())) {
+                        const imp = modelFile.getImports().find(i => ModelUtil.getShortName(i) === keyType);
+                        addImport(imp ? ModelUtil.getNamespace(imp) : modelFile.getNamespace(), keyType);
                     }
-                    properties.get(typeNamespace).add(`I${typeName}`);
-                }
 
-                classDeclaration.getProperties().forEach(property => {
-                    if (!property.isPrimitive()) {
-                        const typeNamespace = ModelUtil.getNamespace(property.getFullyQualifiedTypeName());
-                        const typeName = ModelUtil.getShortName(property.getFullyQualifiedTypeName());
-                        if (!properties.has(typeNamespace)) {
-                            properties.set(typeNamespace, new Set());
-                        }
-                        properties.get(typeNamespace).add(
-                            property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
-                    }
-                });
-
-                const subclasses = classDeclaration.getDirectSubclasses();
-                if (subclasses && subclasses.length > 0) {
-                    parameters.fileWriter.writeLine(0, '\n// Warning: Beware of circular dependencies when modifying these imports');
-
-                    // Group subclasses by namespace
-                    const namespaceBuckets = {};
-                    subclasses.map(subclass => {
-                        const bucket = namespaceBuckets[subclass.getNamespace()];
-                        if (bucket){
-                            bucket.push(subclass);
+                    if (!ModelUtil.isPrimitiveType(valueType)) {
+                        const imp = modelFile.getImports().find(i => ModelUtil.getShortName(i) === valueType);
+                        const typeNamespace = imp ? ModelUtil.getNamespace(imp) : modelFile.getNamespace();
+                        if (ModelUtil.isScalar(declaration.getValue())) {
+                            addImport(typeNamespace, valueType);
                         } else {
-                            namespaceBuckets[subclass.getNamespace()] = [subclass];
+                            const fqn = imp || `${modelFile.getNamespace()}.${valueType}`;
+                            const valueDecl = declaration.getModelFile().getModelManager().getType(fqn);
+                            addImport(typeNamespace, valueDecl?.isEnum?.() ? valueType : `I${valueType}`);
+                        }
+                    }
+                } else if (!declaration.isEnum()) {
+                    if (declaration.getSuperType()) {
+                        const typeNamespace = ModelUtil.getNamespace(declaration.getSuperType());
+                        const typeName = ModelUtil.getShortName(declaration.getSuperType());
+                        addImport(typeNamespace, `I${typeName}`);
+                    }
+
+                    declaration.getProperties().forEach(property => {
+                        if (!property.isPrimitive()) {
+                            const typeNamespace = ModelUtil.getNamespace(property.getFullyQualifiedTypeName());
+                            const typeName = ModelUtil.getShortName(property.getFullyQualifiedTypeName());
+                            addImport(typeNamespace,
+                                property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
                         }
                     });
-                    Object.entries(namespaceBuckets)
-                        .filter(([namespace]) => namespace !== modelFile.getNamespace()) // Skip own namespace
-                        .map(([namespace, bucket]) => {
-                            parameters.fileWriter.writeLine(0, `import type {\n\t${bucket.map(subclass => subclass.isEnum() ? subclass.getName() : `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
-                        });
-                }
 
+                    const subclasses = declaration.getDirectSubclasses();
+                    if (subclasses && subclasses.length > 0) {
+                        parameters.fileWriter.writeLine(0, '\n// Warning: Beware of circular dependencies when modifying these imports');
+
+                        // Group subclasses by namespace
+                        const namespaceBuckets = {};
+                        subclasses.map(subclass => {
+                            const bucket = namespaceBuckets[subclass.getNamespace()];
+                            if (bucket){
+                                bucket.push(subclass);
+                            } else {
+                                namespaceBuckets[subclass.getNamespace()] = [subclass];
+                            }
+                        });
+                        Object.entries(namespaceBuckets)
+                            .filter(([namespace]) => namespace !== modelFile.getNamespace()) // Skip own namespace
+                            .map(([namespace, bucket]) => {
+                                parameters.fileWriter.writeLine(0, `import type {\n\t${bucket.map(subclass => subclass.isEnum() ? subclass.getName() : `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
+                            });
+                    }
+                }
             });
 
         const uniqueNamespaces = new Set(

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6928,7 +6928,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Warning: Beware of circular dependencies when modifying these imports
 
 // Warning: Beware of circular dependencies when modifying these imports
-import {IAddress,IEmployeeTShirtSizes,SSN} from './org.acme.hr.base@1.0.0';
+import {Time,SSN,IAddress,IEmployeeTShirtSizes} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6892,7 +6892,7 @@ export enum TShirtSizeType {
    LARGE = 'LARGE',
 }
 
-export type EmployeeTShirtSizes = Map<string, ITShirtSizeType>;
+export type EmployeeTShirtSizes = Map<SSN, TShirtSizeType>;
 
 export interface IAddress extends IConcept {
    street: string;
@@ -6904,6 +6904,10 @@ export interface IAddress extends IConcept {
 
 export enum Level {
 }
+
+export type Time = Date;
+
+export type SSN = string;
 
 ",
 }
@@ -6924,7 +6928,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Warning: Beware of circular dependencies when modifying these imports
 
 // Warning: Beware of circular dependencies when modifying these imports
-import {IAddress,IEmployeeTShirtSizes,ISSN} from './org.acme.hr.base@1.0.0';
+import {IAddress,IEmployeeTShirtSizes,SSN} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 
@@ -6943,15 +6947,15 @@ export interface IInfo extends IConcept {
 
 export type CompanyProperties = Map<string, string>;
 
-export type EmployeeLoginTimes = Map<string, Date>;
+export type EmployeeLoginTimes = Map<string, Time>;
 
-export type EmployeeSocialSecurityNumbers = Map<string, string>;
+export type EmployeeSocialSecurityNumbers = Map<string, SSN>;
 
-export type NextOfKin = Map<string, string>;
+export type NextOfKin = Map<KinName, KinTelephone>;
 
 export type EmployeeProfiles = Map<string, IConcept>;
 
-export type EmployeeDirectory = Map<string, IEmployee>;
+export type EmployeeDirectory = Map<SSN, IEmployee>;
 
 export interface ICompany extends IConcept {
    name: string;
@@ -6993,7 +6997,7 @@ export interface IPerson extends IParticipant {
    lastName: string;
    middleNames?: string;
    homeAddress: IAddress;
-   ssn: string;
+   ssn: SSN;
    height: number;
    dob: Date;
    nextOfKin: NextOfKin;
@@ -7037,6 +7041,10 @@ export interface IChangeOfAddress extends ITransaction {
    Person: IPerson;
    newAddress: IAddress;
 }
+
+export type KinName = string;
+
+export type KinTelephone = string;
 
 ",
 }

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -124,6 +124,17 @@ describe('TypescriptVisitor', function () {
             mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
+        it('should return visitScalarDeclaration for a ScalarDeclaration', () => {
+            let thing = sinon.createStubInstance(ScalarDeclaration);
+            thing.isScalarDeclaration.returns(true);
+            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitScalarDeclaration');
+            mockSpecialVisit.returns('Duck');
+
+            typescriptVisitor.visit(thing, param).should.deep.equal('Duck');
+
+            mockSpecialVisit.calledWith(thing, param).should.be.ok;
+        });
+
         it('should return visitMapDeclaration for a MapDeclaration', () => {
             let thing = sinon.createStubInstance(MapDeclaration);
             thing.isMapDeclaration.returns(true);
@@ -135,15 +146,11 @@ describe('TypescriptVisitor', function () {
             mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
-        it('should propagate optional modifier for scalar fields via parameters', () => {
-            // Create a mock scalar field
-            let mockScalarField = sinon.createStubInstance(Field);
-            mockScalarField.isOptional.returns(false); // Scalar field itself is not optional
-
-            // Create a thing that is a scalar type field
+        it('should route scalar type fields to visitScalarField', () => {
             let thing = {
                 isModelManager: () => false,
                 isModelFile: () => false,
+                isScalarDeclaration: () => false,
                 isEnum: () => false,
                 isClassDeclaration: () => false,
                 isMapDeclaration: () => false,
@@ -151,21 +158,15 @@ describe('TypescriptVisitor', function () {
                 isField: () => true,
                 isRelationship: () => false,
                 isEnumValue: () => false,
-                isOptional: () => true, // The parent field is optional
-                getScalarField: () => mockScalarField
             };
 
-            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitField');
+            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitScalarField');
             mockSpecialVisit.returns('Duck');
 
             typescriptVisitor.visit(thing, param);
 
-            // Verify that visitField was called with the scalar field
             mockSpecialVisit.calledOnce.should.be.ok;
-            // Verify that forceOptional was passed via parameters (not by mutating the scalar field)
-            const callArgs = mockSpecialVisit.getCall(0).args;
-            callArgs[0].should.equal(mockScalarField);
-            callArgs[1].forceOptional.should.equal(true);
+            mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
         it('should throw an error when an unrecognised type is supplied', () => {
@@ -499,6 +500,85 @@ describe('TypescriptVisitor', function () {
             param.fileWriter.writeLine.withArgs(0, '}\n').calledOnce.should.be.ok;
 
             acceptSpy.withArgs(typescriptVisitor, param).calledTwice.should.be.ok;
+        });
+    });
+
+    describe('visitScalarDeclaration', () => {
+        let param;
+        beforeEach(() => {
+            param = {
+                fileWriter: mockFileWriter
+            };
+        });
+        it('should emit a type alias for a scalar extending String', () => {
+            let mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
+            mockScalarDeclaration.isScalarDeclaration.returns(true);
+            mockScalarDeclaration.getName.returns('EmailAddress');
+            mockScalarDeclaration.getType.returns('String');
+
+            typescriptVisitor.visitScalarDeclaration(mockScalarDeclaration, param);
+
+            param.fileWriter.writeLine.calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type EmailAddress = string;\n').calledOnce.should.be.ok;
+        });
+
+        it('should emit a type alias for a scalar extending DateTime', () => {
+            let mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
+            mockScalarDeclaration.isScalarDeclaration.returns(true);
+            mockScalarDeclaration.getName.returns('RegistrationDate');
+            mockScalarDeclaration.getType.returns('DateTime');
+
+            typescriptVisitor.visitScalarDeclaration(mockScalarDeclaration, param);
+
+            param.fileWriter.writeLine.calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type RegistrationDate = Date;\n').calledOnce.should.be.ok;
+        });
+    });
+
+    describe('visitScalarField', () => {
+        let param;
+        beforeEach(() => {
+            param = {
+                fileWriter: mockFileWriter
+            };
+        });
+        it('should write a field using the scalar type name', () => {
+            let field = {
+                getName: () => 'email',
+                getType: () => 'EmailAddress',
+                isArray: () => false,
+                isOptional: () => false
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'email: EmailAddress;').calledOnce.should.be.ok;
+        });
+
+        it('should handle optional scalar fields', () => {
+            let field = {
+                getName: () => 'email',
+                getType: () => 'EmailAddress',
+                isArray: () => false,
+                isOptional: () => true
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'email?: EmailAddress;').calledOnce.should.be.ok;
+        });
+
+        it('should handle array scalar fields', () => {
+            let field = {
+                getName: () => 'emails',
+                getType: () => 'EmailAddress',
+                isArray: () => true,
+                isOptional: () => false
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'emails: EmailAddress[];').calledOnce.should.be.ok;
         });
     });
 
@@ -859,6 +939,11 @@ describe('TypescriptVisitor', function () {
             });
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
             let mockMapKeyType     = sinon.createStubInstance(MapKeyType);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -887,6 +972,11 @@ describe('TypescriptVisitor', function () {
             });
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
             let mockMapKeyType     = sinon.createStubInstance(MapKeyType);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -914,6 +1004,11 @@ describe('TypescriptVisitor', function () {
             });
 
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -928,6 +1023,37 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
             param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, IConcept>;\n').calledOnce.should.be.ok;
+        });
+
+        it('should write a line with the name, key and value of the map <String, TagSource> where value is an enum', () => {
+            let param = {
+                fileWriter: mockFileWriter
+            };
+            sandbox.restore();
+            sandbox.stub(ModelUtil, 'isScalar').callsFake(() => {
+                return false;
+            });
+
+            let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockEnumDecl     = sinon.createStubInstance(EnumDeclaration);
+            mockEnumDecl.isEnum.returns(true);
+            mockModelFile.getType.returns(mockEnumDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
+
+            const getKeyType    = sinon.stub();
+            const getValueType  = sinon.stub();
+
+            getKeyType.returns('String');
+            getValueType.returns('TagSource');
+            mockMapDeclaration.getName.returns('TagSourceMap');
+            mockMapDeclaration.isMapDeclaration.returns(true);
+            mockMapDeclaration.getKey.returns({ getType: getKeyType });
+            mockMapDeclaration.getValue.returns({ getType: getValueType });
+
+            typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
+
+            param.fileWriter.writeLine.withArgs(0, 'export type TagSourceMap = Map<string, TagSource>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <SSN, String>', () => {
@@ -960,7 +1086,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, string>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<SSN, string>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <String, SSN>', () => {
@@ -993,7 +1119,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, string>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, SSN>;\n').calledOnce.should.be.ok;
         });
     });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Scalar declarations in Concerto models were not emitted by the TypeScript code generator. Scalar-typed fields collapsed to their underlying primitive, losing domain-specific naming. Enum-typed map values were also incorrectly prefixed with `I`.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Scalar declarations are now emitted as TypeScript type aliases (e.g., `scalar EmailAddress extends String → export type EmailAddress = string;`)
- <TWO> Scalar-typed fields use the scalar alias name instead of the collapsed primitive (e.g., created: RegistrationDate instead of created: Date)
- <THREE> Scalar-typed map keys/values preserve the alias name (e.g., Map<SSN, string> instead of Map<string, string>)
- <FOUR> Enum-typed map values no longer get an incorrect I prefix (e.g., Map<string, TagSource> instead of Map<string, ITagSource>)
- <FIVE> Emit imports references for scalar fields referenced via MapDeclarations


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
