### PR TITLE
fix(typescript): scope union aliases to same-namespace with >1 subclass

### DIFF
--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -127,26 +127,6 @@ class TypescriptVisitor {
                     }
                 });
 
-                const subclasses = classDeclaration.getDirectSubclasses();
-                if (subclasses && subclasses.length > 0) {
-                    parameters.fileWriter.writeLine(0, '\n// Warning: Beware of circular dependencies when modifying these imports');
-
-                    // Group subclasses by namespace
-                    const namespaceBuckets = {};
-                    subclasses.map(subclass => {
-                        const bucket = namespaceBuckets[subclass.getNamespace()];
-                        if (bucket){
-                            bucket.push(subclass);
-                        } else {
-                            namespaceBuckets[subclass.getNamespace()] = [subclass];
-                        }
-                    });
-                    Object.entries(namespaceBuckets)
-                        .filter(([namespace]) => namespace !== modelFile.getNamespace()) // Skip own namespace
-                        .map(([namespace, bucket]) => {
-                            parameters.fileWriter.writeLine(0, `import type {\n\t${bucket.map(subclass => subclass.isEnum() ? subclass.getName() : `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
-                        });
-                }
 
             });
 
@@ -225,11 +205,15 @@ class TypescriptVisitor {
 
         parameters.fileWriter.writeLine(0, '}\n');
 
-        // If there exists direct subclasses for this declaration then generate a union for it
+        // Generate a union alias only when there are multiple same-namespace subclasses
         const subclasses = classDeclaration.getDirectSubclasses();
-        if (subclasses && subclasses.length > 0) {
-            parameters.fileWriter.writeLine(0, 'export type ' + classDeclaration.getName() +
-                'Union = ' + subclasses.filter(declaration => !declaration.isEnum()).map(subclass => `I${subclass.getName()}`).join(' | \n') + ';\n');
+        if (subclasses) {
+            const sameNsSubclasses = subclasses
+                .filter(sc => !sc.isEnum() && sc.getNamespace() === classDeclaration.getNamespace());
+            if (sameNsSubclasses.length > 1) {
+                parameters.fileWriter.writeLine(0, 'export type ' + classDeclaration.getName() +
+                    'Union = ' + sameNsSubclasses.map(subclass => `I${subclass.getName()}`).join(' | \n') + ';\n');
+            }
         }
         return null;
     }
@@ -281,12 +265,17 @@ class TypescriptVisitor {
 
         let tsType = this.toTsType(field.getType(), !isEnumRef && !hasUnion && !isMapRef, hasUnion);
 
-        // If there exists direct subclasses for this field's declaration then use the union type instead
+        // Use the union type only when there are multiple same-namespace subclasses
         if (!!parameters.flattenSubclassesToUnion & !field.isPrimitive()) {
-            const subclasses = field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName()).getDirectSubclasses();
-            if (subclasses && subclasses.length > 0) {
-                const useUnion = !(isEnumRef || isMapRef);
-                tsType = this.toTsType(field.getType(), !useUnion, useUnion);
+            const fieldDecl = field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName());
+            const subclasses = fieldDecl.getDirectSubclasses();
+            if (subclasses) {
+                const sameNsSubclasses = subclasses
+                    .filter(sc => !sc.isEnum() && sc.getNamespace() === fieldDecl.getNamespace());
+                if (sameNsSubclasses.length > 1) {
+                    const useUnion = !(isEnumRef || isMapRef);
+                    tsType = this.toTsType(field.getType(), !useUnion, useUnion);
+                }
             }
         }
 

--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -40,6 +40,8 @@ class TypescriptVisitor {
             return this.visitModelManager(thing, parameters);
         } else if (thing.isModelFile?.()) {
             return this.visitModelFile(thing, parameters);
+        } else if (thing.isScalarDeclaration?.()) {
+            return this.visitScalarDeclaration(thing, parameters);
         } else if (thing.isEnum?.()) {
             return this.visitEnumDeclaration(thing, parameters);
         } else if (thing.isClassDeclaration?.()) {
@@ -47,10 +49,7 @@ class TypescriptVisitor {
         } else if (thing.isMapDeclaration?.()) {
             return this.visitMapDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
-            // Propagate optional modifier from the field to visitField via parameters
-            // Avoid mutating the shared scalar descriptor
-            const scalarField = thing.getScalarField();
-            return this.visitField(scalarField, { ...parameters, forceOptional: thing.isOptional() });
+            return this.visitScalarField(thing, parameters);
         } else if (thing.isField?.()) {
             return this.visitField(thing, parameters);
         } else if (thing.isRelationship?.()) {
@@ -123,7 +122,8 @@ class TypescriptVisitor {
                         if (!properties.has(typeNamespace)) {
                             properties.set(typeNamespace, new Set());
                         }
-                        properties.get(typeNamespace).add(property.isTypeEnum?.() ? typeName : `I${typeName}`);
+                        properties.get(typeNamespace).add(
+                            property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
                     }
                 });
 
@@ -169,10 +169,9 @@ class TypescriptVisitor {
 
         parameters.fileWriter.writeLine(0, '\n// interfaces');
         parameters.aliasedTypesMap = aliasedTypesMap;
-        modelFile.getAllDeclarations()
-            .filter(declaration => !declaration.isScalarDeclaration?.()).forEach((decl) => {
-                decl.accept(this, parameters);
-            });
+        modelFile.getAllDeclarations().forEach((decl) => {
+            decl.accept(this, parameters);
+        });
 
         parameters.fileWriter.closeFile();
 
@@ -237,6 +236,19 @@ class TypescriptVisitor {
 
     /**
      * Visitor design pattern
+     * @param {Object} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitScalarDeclaration(scalarDeclaration, parameters) {
+        const tsType = this.toTsType(scalarDeclaration.getType(), false, false);
+        parameters.fileWriter.writeLine(0, `export type ${scalarDeclaration.getName()} = ${tsType};\n`);
+        return null;
+    }
+
+    /**
+     * Visitor design pattern
      * @param {Field} field - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
@@ -288,6 +300,20 @@ class TypescriptVisitor {
     }
 
     /**
+     * Visitor design pattern - handles fields whose type is a scalar declaration
+     * @param {Object} field - the scalar-typed field being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitScalarField(field, parameters) {
+        let array = field.isArray() ? '[]' : '';
+        let optional = field.isOptional() ? '?' : '';
+        parameters.fileWriter.writeLine(1, field.getName() + optional + ': ' + field.getType() + array + ';');
+        return null;
+    }
+
+    /**
      * Visitor design pattern
      * @param {EnumValueDeclaration} enumValueDeclaration - the object being visited
      * @param {Object} parameters  - the parameter
@@ -318,20 +344,18 @@ class TypescriptVisitor {
         if (ModelUtil.isPrimitiveType(mapKeyType)) {
             keyType = this.toTsType(mapDeclaration.getKey().getType(), false, false);
         } else if (ModelUtil.isScalar(mapDeclaration.getKey())) {
-            const scalarDeclaration = mapDeclaration.getModelFile().getType(mapDeclaration.getKey().getType());
-            const scalarType = scalarDeclaration.getType();
-            keyType = this.toTsType(scalarType, false, false);
+            keyType = mapKeyType;
         }
 
         // Map Value Type
         if (ModelUtil.isPrimitiveType(mapValueType)) {
             valueType = this.toTsType(mapDeclaration.getValue().getType(), false, false);
         } else if (ModelUtil.isScalar(mapDeclaration.getValue())) {
-            const scalarDeclaration = mapDeclaration.getModelFile().getType(mapDeclaration.getValue().getType());
-            const scalarType = scalarDeclaration.getType();
-            valueType = this.toTsType(scalarType, false, false);
+            valueType = mapValueType;
         } else {
-            valueType = this.toTsType(mapValueType, true, false);
+            const valueDecl = mapDeclaration.getModelFile().getType(mapValueType);
+            const isEnum = valueDecl?.isEnum?.();
+            valueType = this.toTsType(mapValueType, !isEnum, false);
         }
 
         parameters.fileWriter.writeLine(0, 'export type ' + mapDeclaration.getName() + ` = Map<${keyType}, ${valueType}>;\n` );

--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -285,7 +285,7 @@ class TypescriptVisitor {
         let tsType = this.toTsType(field.getType(), !isEnumRef && !hasUnion && !isMapRef, hasUnion);
 
         // Use the union type only when there are multiple same-namespace subclasses
-        if (!!parameters.flattenSubclassesToUnion & !field.isPrimitive()) {
+        if (!!parameters.flattenSubclassesToUnion && !field.isPrimitive()) {
             const fieldDecl = field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName());
             const subclasses = fieldDecl.getDirectSubclasses();
             if (subclasses) {

--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -130,12 +130,6 @@ class TypescriptVisitor {
                             const valueDecl = declaration.getModelFile().getModelManager().getType(fqn);
                             addImport(typeNamespace, valueDecl?.isEnum?.() ? valueType : `I${valueType}`);
                         }
-                        properties.get(typeNamespace).add(
-                            property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
-                    }
-                });
-
-
                     }
                 } else if (!declaration.isEnum()) {
                     if (declaration.getSuperType()) {
@@ -152,27 +146,6 @@ class TypescriptVisitor {
                                 property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
                         }
                     });
-
-                    const subclasses = declaration.getDirectSubclasses();
-                    if (subclasses && subclasses.length > 0) {
-                        parameters.fileWriter.writeLine(0, '\n// Warning: Beware of circular dependencies when modifying these imports');
-
-                        // Group subclasses by namespace
-                        const namespaceBuckets = {};
-                        subclasses.map(subclass => {
-                            const bucket = namespaceBuckets[subclass.getNamespace()];
-                            if (bucket){
-                                bucket.push(subclass);
-                            } else {
-                                namespaceBuckets[subclass.getNamespace()] = [subclass];
-                            }
-                        });
-                        Object.entries(namespaceBuckets)
-                            .filter(([namespace]) => namespace !== modelFile.getNamespace()) // Skip own namespace
-                            .map(([namespace, bucket]) => {
-                                parameters.fileWriter.writeLine(0, `import type {\n\t${bucket.map(subclass => subclass.isEnum() ? subclass.getName() : `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
-                            });
-                    }
                 }
             });
 

--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -144,6 +144,19 @@ class TypescriptVisitor {
                             const typeName = ModelUtil.getShortName(property.getFullyQualifiedTypeName());
                             addImport(typeNamespace,
                                 property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
+
+                            // When flattenSubclassesToUnion is set, also import the union type
+                            if (parameters.flattenSubclassesToUnion && !property.isTypeEnum?.() && !property.isTypeScalar?.()) {
+                                const propDecl = modelFile.getModelManager().getType(property.getFullyQualifiedTypeName());
+                                const subclasses = propDecl?.getDirectSubclasses?.();
+                                if (subclasses) {
+                                    const sameNsSubs = subclasses.filter(sc =>
+                                        !sc.isEnum() && sc.getNamespace() === propDecl.getNamespace());
+                                    if (sameNsSubs.length > 1) {
+                                        addImport(typeNamespace, `${typeName}Union`);
+                                    }
+                                }
+                            }
                         }
                     });
                 }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6753,18 +6753,11 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: concerto.decorator@1.0.0
 
 // imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	Ipii
-} from './org.acme.hr@1.0.0';
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
 export interface IDecorator extends IConcept {
 }
-
-export type DecoratorUnion = Ipii;
 
 export interface IDotNetNamespace extends IDecorator {
    namespace: string;
@@ -6782,76 +6775,26 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 
 // imports
 
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	ICategory,
-	State,
-	TShirtSizeType,
-	IAddress,
-	Level
-} from './org.acme.hr.base@1.0.0';
-import type {
-	ICategory,
-	IInfo,
-	ICompany,
-	Department,
-	LaptopMake
-} from './org.acme.hr@1.0.0';
-
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	IEquipment
-} from './org.acme.hr@1.0.0';
-
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	IPerson
-} from './org.acme.hr@1.0.0';
-
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	IChangeOfAddress
-} from './org.acme.hr@1.0.0';
-
-// Warning: Beware of circular dependencies when modifying these imports
-import type {
-	ICompanyEvent
-} from './org.acme.hr@1.0.0';
-
 // interfaces
 export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = ICategory | 
-IAddress | 
-ICategory | 
-IInfo | 
-ICompany;
-
 export interface IAsset extends IConcept {
    $identifier: string;
 }
-
-export type AssetUnion = IEquipment;
 
 export interface IParticipant extends IConcept {
    $identifier: string;
 }
 
-export type ParticipantUnion = IPerson;
-
 export interface ITransaction extends IConcept {
    $timestamp: Date;
 }
 
-export type TransactionUnion = IChangeOfAddress;
-
 export interface IEvent extends IConcept {
    $timestamp: Date;
 }
-
-export type EventUnion = ICompanyEvent;
 
 ",
 }
@@ -6864,15 +6807,11 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: org.acme.hr.base@1.0.0
 
 // imports
-
-// Warning: Beware of circular dependencies when modifying these imports
 import {IConcept} from './concerto@1.0.0';
 
 // interfaces
 export interface ICategory extends IConcept {
 }
-
-export type CategoryUnion = IGeneralCategory;
 
 export interface IGeneralCategory extends ICategory {
 }
@@ -6920,14 +6859,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: org.acme.hr@1.0.0
 
 // imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
 import {IAddress,IEmployeeTShirtSizes,SSN} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
@@ -6980,8 +6911,6 @@ export interface IEquipment extends IAsset {
    serialNumber: string;
 }
 
-export type EquipmentUnion = ILaptop;
-
 export enum LaptopMake {
    Apple = 'Apple',
    Microsoft = 'Microsoft',
@@ -7017,8 +6946,6 @@ export interface IEmployee extends IPerson {
    manager?: IManager;
 }
 
-export type EmployeeUnion = IManager;
-
 export interface IContractor extends IPerson {
    company: ICompany;
    manager?: IManager;
@@ -7030,8 +6957,6 @@ export interface IManager extends IEmployee {
 
 export interface ICompanyEvent extends IEvent {
 }
-
-export type CompanyEventUnion = IOnboarded;
 
 export interface IOnboarded extends ICompanyEvent {
    employee: IEmployee;

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6859,15 +6859,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Generated code for namespace: org.acme.hr@1.0.0
 
 // imports
-import {IAddress,IEmployeeTShirtSizes,SSN} from './org.acme.hr.base@1.0.0';
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
-
-// Warning: Beware of circular dependencies when modifying these imports
 import {Time,SSN,IAddress,IEmployeeTShirtSizes} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6892,7 +6892,7 @@ export enum TShirtSizeType {
    LARGE = 'LARGE',
 }
 
-export type EmployeeTShirtSizes = Map<string, ITShirtSizeType>;
+export type EmployeeTShirtSizes = Map<SSN, TShirtSizeType>;
 
 export interface IAddress extends IConcept {
    street: string;
@@ -6904,6 +6904,10 @@ export interface IAddress extends IConcept {
 
 export enum Level {
 }
+
+export type Time = Date;
+
+export type SSN = string;
 
 ",
 }
@@ -6924,7 +6928,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Warning: Beware of circular dependencies when modifying these imports
 
 // Warning: Beware of circular dependencies when modifying these imports
-import {IAddress,IEmployeeTShirtSizes,ISSN} from './org.acme.hr.base@1.0.0';
+import {IAddress,IEmployeeTShirtSizes,SSN} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 
@@ -6943,15 +6947,15 @@ export interface IInfo extends IConcept {
 
 export type CompanyProperties = Map<string, string>;
 
-export type EmployeeLoginTimes = Map<string, Date>;
+export type EmployeeLoginTimes = Map<string, Time>;
 
-export type EmployeeSocialSecurityNumbers = Map<string, string>;
+export type EmployeeSocialSecurityNumbers = Map<string, SSN>;
 
-export type NextOfKin = Map<string, string>;
+export type NextOfKin = Map<KinName, KinTelephone>;
 
 export type EmployeeProfiles = Map<string, IConcept>;
 
-export type EmployeeDirectory = Map<string, IEmployee>;
+export type EmployeeDirectory = Map<SSN, IEmployee>;
 
 export interface ICompany extends IConcept {
    name: string;
@@ -6993,7 +6997,7 @@ export interface IPerson extends IParticipant {
    lastName: string;
    middleNames?: string;
    homeAddress: IAddress;
-   ssn: string;
+   ssn: SSN;
    height: number;
    dob: Date;
    nextOfKin: NextOfKin;
@@ -7037,6 +7041,10 @@ export interface IChangeOfAddress extends ITransaction {
    Person: IPerson;
    newAddress: IAddress;
 }
+
+export type KinName = string;
+
+export type KinTelephone = string;
 
 ",
 }

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -124,6 +124,17 @@ describe('TypescriptVisitor', function () {
             mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
+        it('should return visitScalarDeclaration for a ScalarDeclaration', () => {
+            let thing = sinon.createStubInstance(ScalarDeclaration);
+            thing.isScalarDeclaration.returns(true);
+            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitScalarDeclaration');
+            mockSpecialVisit.returns('Duck');
+
+            typescriptVisitor.visit(thing, param).should.deep.equal('Duck');
+
+            mockSpecialVisit.calledWith(thing, param).should.be.ok;
+        });
+
         it('should return visitMapDeclaration for a MapDeclaration', () => {
             let thing = sinon.createStubInstance(MapDeclaration);
             thing.isMapDeclaration.returns(true);
@@ -135,15 +146,11 @@ describe('TypescriptVisitor', function () {
             mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
-        it('should propagate optional modifier for scalar fields via parameters', () => {
-            // Create a mock scalar field
-            let mockScalarField = sinon.createStubInstance(Field);
-            mockScalarField.isOptional.returns(false); // Scalar field itself is not optional
-
-            // Create a thing that is a scalar type field
+        it('should route scalar type fields to visitScalarField', () => {
             let thing = {
                 isModelManager: () => false,
                 isModelFile: () => false,
+                isScalarDeclaration: () => false,
                 isEnum: () => false,
                 isClassDeclaration: () => false,
                 isMapDeclaration: () => false,
@@ -151,21 +158,15 @@ describe('TypescriptVisitor', function () {
                 isField: () => true,
                 isRelationship: () => false,
                 isEnumValue: () => false,
-                isOptional: () => true, // The parent field is optional
-                getScalarField: () => mockScalarField
             };
 
-            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitField');
+            let mockSpecialVisit = sinon.stub(typescriptVisitor, 'visitScalarField');
             mockSpecialVisit.returns('Duck');
 
             typescriptVisitor.visit(thing, param);
 
-            // Verify that visitField was called with the scalar field
             mockSpecialVisit.calledOnce.should.be.ok;
-            // Verify that forceOptional was passed via parameters (not by mutating the scalar field)
-            const callArgs = mockSpecialVisit.getCall(0).args;
-            callArgs[0].should.equal(mockScalarField);
-            callArgs[1].forceOptional.should.equal(true);
+            mockSpecialVisit.calledWith(thing, param).should.be.ok;
         });
 
         it('should throw an error when an unrecognised type is supplied', () => {
@@ -499,6 +500,85 @@ describe('TypescriptVisitor', function () {
             param.fileWriter.writeLine.withArgs(0, '}\n').calledOnce.should.be.ok;
 
             acceptSpy.withArgs(typescriptVisitor, param).calledTwice.should.be.ok;
+        });
+    });
+
+    describe('visitScalarDeclaration', () => {
+        let param;
+        beforeEach(() => {
+            param = {
+                fileWriter: mockFileWriter
+            };
+        });
+        it('should emit a type alias for a scalar extending String', () => {
+            let mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
+            mockScalarDeclaration.isScalarDeclaration.returns(true);
+            mockScalarDeclaration.getName.returns('EmailAddress');
+            mockScalarDeclaration.getType.returns('String');
+
+            typescriptVisitor.visitScalarDeclaration(mockScalarDeclaration, param);
+
+            param.fileWriter.writeLine.calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type EmailAddress = string;\n').calledOnce.should.be.ok;
+        });
+
+        it('should emit a type alias for a scalar extending DateTime', () => {
+            let mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
+            mockScalarDeclaration.isScalarDeclaration.returns(true);
+            mockScalarDeclaration.getName.returns('RegistrationDate');
+            mockScalarDeclaration.getType.returns('DateTime');
+
+            typescriptVisitor.visitScalarDeclaration(mockScalarDeclaration, param);
+
+            param.fileWriter.writeLine.calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type RegistrationDate = Date;\n').calledOnce.should.be.ok;
+        });
+    });
+
+    describe('visitScalarField', () => {
+        let param;
+        beforeEach(() => {
+            param = {
+                fileWriter: mockFileWriter
+            };
+        });
+        it('should write a field using the scalar type name', () => {
+            let field = {
+                getName: () => 'email',
+                getType: () => 'EmailAddress',
+                isArray: () => false,
+                isOptional: () => false
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'email: EmailAddress;').calledOnce.should.be.ok;
+        });
+
+        it('should handle optional scalar fields', () => {
+            let field = {
+                getName: () => 'email',
+                getType: () => 'EmailAddress',
+                isArray: () => false,
+                isOptional: () => true
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'email?: EmailAddress;').calledOnce.should.be.ok;
+        });
+
+        it('should handle array scalar fields', () => {
+            let field = {
+                getName: () => 'emails',
+                getType: () => 'EmailAddress',
+                isArray: () => true,
+                isOptional: () => false
+            };
+
+            typescriptVisitor.visitScalarField(field, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'emails: EmailAddress[];').calledOnce.should.be.ok;
         });
     });
 
@@ -859,6 +939,11 @@ describe('TypescriptVisitor', function () {
             });
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
             let mockMapKeyType     = sinon.createStubInstance(MapKeyType);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -887,6 +972,11 @@ describe('TypescriptVisitor', function () {
             });
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
             let mockMapKeyType     = sinon.createStubInstance(MapKeyType);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -914,6 +1004,11 @@ describe('TypescriptVisitor', function () {
             });
 
             let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockValueDecl    = sinon.createStubInstance(ClassDeclaration);
+            mockValueDecl.isEnum.returns(false);
+            mockModelFile.getType.returns(mockValueDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
 
             const getKeyType    = sinon.stub();
             const getValueType  = sinon.stub();
@@ -928,6 +1023,37 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
             param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, IConcept>;\n').calledOnce.should.be.ok;
+        });
+
+        it('should write a line with the name, key and value of the map <String, TagSource> where value is an enum', () => {
+            let param = {
+                fileWriter: mockFileWriter
+            };
+            sandbox.restore();
+            sandbox.stub(ModelUtil, 'isScalar').callsFake(() => {
+                return false;
+            });
+
+            let mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
+            const mockModelFile    = sinon.createStubInstance(ModelFile);
+            const mockEnumDecl     = sinon.createStubInstance(EnumDeclaration);
+            mockEnumDecl.isEnum.returns(true);
+            mockModelFile.getType.returns(mockEnumDecl);
+            mockMapDeclaration.getModelFile.returns(mockModelFile);
+
+            const getKeyType    = sinon.stub();
+            const getValueType  = sinon.stub();
+
+            getKeyType.returns('String');
+            getValueType.returns('TagSource');
+            mockMapDeclaration.getName.returns('TagSourceMap');
+            mockMapDeclaration.isMapDeclaration.returns(true);
+            mockMapDeclaration.getKey.returns({ getType: getKeyType });
+            mockMapDeclaration.getValue.returns({ getType: getValueType });
+
+            typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
+
+            param.fileWriter.writeLine.withArgs(0, 'export type TagSourceMap = Map<string, TagSource>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <SSN, String>', () => {
@@ -960,7 +1086,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, string>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<SSN, string>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <String, SSN>', () => {
@@ -993,7 +1119,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, string>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, SSN>;\n').calledOnce.should.be.ok;
         });
     });
 

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -352,7 +352,7 @@ describe('TypescriptVisitor', function () {
             acceptSpy.withArgs(typescriptVisitor, param).calledTwice.should.be.ok;
         });
 
-        it('should write lines for the imports of direct subclasses that are not in the same namespace', () => {
+        it('should not write cross-namespace subclass imports since unions are scoped to same namespace', () => {
             let acceptSpy = sinon.spy();
 
             let mockSubclassDeclaration1 = sinon.createStubInstance(ClassDeclaration);
@@ -397,13 +397,11 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitModelFile(mockModelFile, param);
 
             param.fileWriter.openFile.withArgs('org.acme.ts').calledOnce.should.be.ok;
-            param.fileWriter.writeLine.callCount.should.deep.equal(6);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, '/* eslint-disable @typescript-eslint/no-empty-interface */']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, '// Generated code for namespace: org.acme']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '\n// imports']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, '\n// Warning: Beware of circular dependencies when modifying these imports']);
-            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([0, 'import type {\n\tIImportedDirectSubclass,\n\tIImportedDirectSubclass2\n} from \'./org.acme.subclasses\';']);
-            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([0, '\n// interfaces']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, '\n// interfaces']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
 
             acceptSpy.withArgs(typescriptVisitor, param).calledOnce.should.be.ok;
@@ -631,7 +629,7 @@ describe('TypescriptVisitor', function () {
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, '}\n']);
         });
 
-        it('should create a union given a class that has dependencies but no super class', () => {
+        it('should not create a union given a class with only one same-namespace subclass', () => {
             let acceptSpy = sinon.spy();
 
             let mockChildClassDeclaration = sinon.createStubInstance(ClassDeclaration);
@@ -643,6 +641,7 @@ describe('TypescriptVisitor', function () {
                 accept: acceptSpy
             }]);
             mockChildClassDeclaration.getName.returns('Child');
+            mockChildClassDeclaration.getNamespace.returns('org.acme');
             mockChildClassDeclaration.isAbstract.returns(false);
             mockChildClassDeclaration.getSuperType.returns('Parent');
 
@@ -655,9 +654,44 @@ describe('TypescriptVisitor', function () {
                 accept: acceptSpy
             }]);
             mockClassDeclaration.getName.returns('Parent');
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.isAbstract.returns(true);
             mockClassDeclaration.getSuperType.returns(null);
             mockClassDeclaration.getDirectSubclasses.returns([mockChildClassDeclaration]);
+
+            typescriptVisitor.visitClassDeclaration(mockClassDeclaration, param);
+
+            param.fileWriter.writeLine.callCount.should.deep.equal(3);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'export interface IParent {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, '$class: string;']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '}\n']);
+        });
+
+        it('should create a union given a class with multiple same-namespace subclasses', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockChildClassDeclaration1 = sinon.createStubInstance(ClassDeclaration);
+            mockChildClassDeclaration1.isClassDeclaration.returns(true);
+            mockChildClassDeclaration1.getName.returns('Child1');
+            mockChildClassDeclaration1.getNamespace.returns('org.acme');
+            mockChildClassDeclaration1.isAbstract.returns(false);
+
+            let mockChildClassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
+            mockChildClassDeclaration2.isClassDeclaration.returns(true);
+            mockChildClassDeclaration2.getName.returns('Child2');
+            mockChildClassDeclaration2.getNamespace.returns('org.acme');
+            mockChildClassDeclaration2.isAbstract.returns(false);
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getOwnProperties.returns([{
+                accept: acceptSpy
+            }]);
+            mockClassDeclaration.getName.returns('Parent');
+            mockClassDeclaration.getNamespace.returns('org.acme');
+            mockClassDeclaration.isAbstract.returns(true);
+            mockClassDeclaration.getSuperType.returns(null);
+            mockClassDeclaration.getDirectSubclasses.returns([mockChildClassDeclaration1, mockChildClassDeclaration2]);
 
             typescriptVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
@@ -665,7 +699,7 @@ describe('TypescriptVisitor', function () {
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'export interface IParent {']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, '$class: string;']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '}\n']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'export type ParentUnion = IChild;\n']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'export type ParentUnion = IChild1 | \nIChild2;\n']);
         });
 
         it('should not create a union if a class has no sub-classes', () => {
@@ -832,7 +866,7 @@ describe('TypescriptVisitor', function () {
             param.fileWriter.writeLine.withArgs(1, 'literalTest = EnumType.MyEnumValue;').calledOnce.should.be.ok;
         });
 
-        it('should write a line for field name using a union type when the flattenSubclassesToUnion parameter is set', () => {
+        it('should write a line for field name using a union type when the flattenSubclassesToUnion parameter is set and there are multiple same-namespace subclasses', () => {
             const mockField = sinon.createStubInstance(Field);
             mockField.isPrimitive.returns(false);
             mockField.getName.returns('flattenSubclassesTest');
@@ -842,7 +876,16 @@ describe('TypescriptVisitor', function () {
             const mockModelManager = sinon.createStubInstance(ModelManager);
             const mockModelFile = sinon.createStubInstance(ModelFile);
             const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
-            mockClassDeclaration.getDirectSubclasses.returns(['blah']); // Not valid, but sufficient for this test
+
+            const mockSubclass1 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclass1.getNamespace.returns('org.acme');
+            mockSubclass1.isEnum.returns(false);
+            const mockSubclass2 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclass2.getNamespace.returns('org.acme');
+            mockSubclass2.isEnum.returns(false);
+
+            mockClassDeclaration.getDirectSubclasses.returns([mockSubclass1, mockSubclass2]);
+            mockClassDeclaration.getNamespace.returns('org.acme');
 
             mockModelManager.getType.returns(mockClassDeclaration);
             mockClassDeclaration.isEnum.returns(false);
@@ -852,6 +895,34 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitField(mockField, { ...param, flattenSubclassesToUnion: true });
 
             param.fileWriter.writeLine.withArgs(1, 'flattenSubclassesTest: AnimalUnion;').calledOnce.should.be.ok;
+        });
+
+        it('should not use union type when flattenSubclassesToUnion is set but there is only one same-namespace subclass', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('singleSubclassTest');
+            mockField.getType.returns('Animal');
+            mockField.getDecorators.returns([]);
+
+            const mockModelManager = sinon.createStubInstance(ModelManager);
+            const mockModelFile = sinon.createStubInstance(ModelFile);
+            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+
+            const mockSubclass1 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclass1.getNamespace.returns('org.acme');
+            mockSubclass1.isEnum.returns(false);
+
+            mockClassDeclaration.getDirectSubclasses.returns([mockSubclass1]);
+            mockClassDeclaration.getNamespace.returns('org.acme');
+
+            mockModelManager.getType.returns(mockClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockField.getParent.returns(mockClassDeclaration);
+            typescriptVisitor.visitField(mockField, { ...param, flattenSubclassesToUnion: true });
+
+            param.fileWriter.writeLine.withArgs(1, 'singleSubclassTest: IAnimal;').calledOnce.should.be.ok;
         });
     });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

Union aliases were generated for single-subclass cases (producing useless singleton unions like `type XUnion = IChild`) and pulled cross-namespace subclasses into the parent namespace, creating inverted dependencies, potential name collisions, and unbounded unions on system types like Concept.

**PS**: Cross-namespace unions are a consumer-side concern; they compose the union from the specific subtypes they need.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Union alias emission now requires >1 non-enum direct subclass in the same namespace before generating `export type XUnion = ...`
- <TWO> `flattenSubclassesToUnion` field behavior applies the same >1 same-namespace threshold
- <THREE> Cross-namespace subclass imports removed, parent namespaces no longer import type from child namespaces solely to define unions

### Before
#### Example 1: Duplicate members in union

`concerto@1.0.0` generates a `ConceptUnion` that includes cross-namespace subclasses. The result has `ICategory` multiple times (one from each namespace that extends Concept):

```
// Before — concerto@1.0.0.ts
export type ConceptUnion = ICategory | 
IAddress | 
ICategory |   // ← duplicate
IInfo | 
ICompany;
```

This union is unusable: TypeScript deduplicates the duplicate `ICategory`, but the intent is ambiguous (which `ICategory`?), and none of these types are defined in this file's namespace.


#### Example 2: Singleton unions are noise

Every parent with exactly one subclass gets a union that's just an alias for one type:
```
// Before
export type AssetUnion = IEquipment;
export type ParticipantUnion = IPerson;
export type EmployeeUnion = IManager;
export type CompanyEventUnion = IOnboarded;
export type CategoryUnion = IGeneralCategory;
```

A union of one type adds no value; `AssetUnion` is just `IEquipment`. Consumers can use `IEquipment` directly.

#### Example 3: Cross-namespace imports only existed to feed these unions

To build the broken unions, we imported every subclass from every namespace:

```
// Before — concerto@1.0.0.ts
// Warning: Beware of circular dependencies when modifying these imports
import type { IEquipment } from './org.acme.hr@1.0.0';
// Warning: Beware of circular dependencies when modifying these imports
import type { IPerson } from './org.acme.hr@1.0.0';
// Warning: Beware of circular dependencies when modifying these imports
import type { IChangeOfAddress } from './org.acme.hr@1.0.0';
// Warning: Beware of circular dependencies when modifying these imports
import type { ICompanyEvent } from './org.acme.hr@1.0.0';
```

Separate import type blocks from the same namespace (not even consolidated), each with a circular-dependency warning. These imports were only needed for the singleton unions above; removing the broken unions removes the need for these imports entirely.

### After

#### Example 1: No broken union

```
// After — concerto@1.0.0.ts
export interface IConcept {
   $class: string;
}
// No ConceptUnion — subclasses span multiple namespaces
```

#### Example 2: No singleton unions

```
// After
export interface IAsset extends IConcept {
   $identifier: string;
}
// No AssetUnion — only one subclass (IEquipment)

export interface IParticipant extends IConcept {
   $identifier: string;
}
// No ParticipantUnion — only one subclass (IPerson)

export interface IEmployee extends IPerson {
   manager?: IManager;
}
// No EmployeeUnion — only one subclass (IManager)
```

#### Example 3: No cross-namespace import noise

```
// After — concerto@1.0.0.ts
// imports
// (no cross-namespace subclass imports — no warnings, no circular deps)

// interfaces
export interface IConcept {
   $class: string;
}

export interface IAsset extends IConcept {
   $identifier: string;
}

export interface IParticipant extends IConcept {
   $identifier: string;
}

export interface ITransaction extends IConcept {
   $timestamp: Date;
}

export interface IEvent extends IConcept {
   $timestamp: Date;
}
```

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
