### PR TITLE
fix(csharp): correct Double→double, field array/nullable order, and optional relationship type

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -400,8 +400,8 @@ class CSharpVisitor {
             field.getParent()?.getName(),
             field.getName(),
             fieldType,
-            nullableType,
             array,
+            nullableType,
             '{ get; set; }',
             parameters
         );
@@ -462,13 +462,18 @@ class CSharpVisitor {
         }
 
         // we export all relationships
+        let nullableType = '';
+        if (relationship.isOptional()) {
+            nullableType = '?';
+        }
+
         const lines = this.toCSharpProperty(
             'public',
             relationship.getParent()?.getName(),
             relationship.getName(),
             type,
-            '',
             array,
+            nullableType,
             '{ get; set; }',
             parameters
         );
@@ -582,7 +587,7 @@ class CSharpVisitor {
         case 'String':
             return 'string';
         case 'Double':
-            return 'float';
+            return 'double';
         case 'Long':
             return 'long';
         case 'Integer':

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -828,7 +828,7 @@ public abstract class Person : Participant {
    public org.acme.hr.base.Address homeAddress { get; set; }
    [System.ComponentModel.DataAnnotations.RegularExpression(@"(\\d{3}-\\d{2}-\\d{4})+", ErrorMessage = "Invalid characters")]
    public string ssn { get; set; }
-   public float height { get; set; }
+   public double height { get; set; }
    public System.DateTime dob { get; set; }
    public Dictionary<string, string> nextOfKin { get; set; }
 }
@@ -844,7 +844,7 @@ public class Employee : Person {
    public Department department { get; set; }
    public org.acme.hr.base.Address officeAddress { get; set; }
    public Equipment[] companyAssets { get; set; }
-   public Manager manager { get; set; }
+   public Manager? manager { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Contractor")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
@@ -852,14 +852,14 @@ public class Contractor : Person {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.Contractor";
    public Company company { get; set; }
-   public Manager manager { get; set; }
+   public Manager? manager { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Manager")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public class Manager : Employee {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.Manager";
-   public Person[] reports { get; set; }
+   public Person[]? reports { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "CompanyEvent")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -434,14 +434,66 @@ describe('CSharpVisitor', function () {
             file1.should.match(/public string\? Value/);
             file1.should.match(/public int\? NullableIntValue/);
             file1.should.match(/public int NonNullableIntValue/);
-            file1.should.match(/public float\? NullableDoubleValue/);
-            file1.should.match(/public float NonNullableDoubleValue/);
+            file1.should.match(/public double\? NullableDoubleValue/);
+            file1.should.match(/public double NonNullableDoubleValue/);
             file1.should.match(/public bool\? NullableBooleanValue/);
             file1.should.match(/public bool NonNullableBooleanValue/);
             file1.should.match(/public System.DateTime\? NullableDateTimeValue/);
             file1.should.match(/public System.DateTime NonNullableDateTimeValue/);
             file1.should.match(/public long\? NullableLongValue/);
             file1.should.match(/public long NonNullableLongValue/);
+        });
+
+        it('should correctly emit [] and ? for all combinations of array and optional on fields and relationships', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            concept Item identified by itemId {
+                o String itemId
+            }
+
+            concept Container {
+                // primitive fields
+                o String requiredField
+                o String optionalField optional
+                o String[] requiredArray
+                o String[] optionalArray optional
+
+                // concept fields
+                o Item requiredConcept
+                o Item optionalConcept optional
+                o Item[] requiredConceptArray
+                o Item[] optionalConceptArray optional
+
+                // relationships
+                --> Item requiredRel
+                --> Item optionalRel optional
+                --> Item[] requiredRelArray
+                --> Item[] optionalRelArray optional
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.0.0.cs');
+
+            // primitive fields
+            file1.should.match(/public string requiredField \{ get; set; \}/);
+            file1.should.match(/public string\? optionalField \{ get; set; \}/);
+            file1.should.match(/public string\[\] requiredArray \{ get; set; \}/);
+            file1.should.match(/public string\[\]\? optionalArray \{ get; set; \}/);
+
+            // concept fields
+            file1.should.match(/public Item requiredConcept \{ get; set; \}/);
+            file1.should.match(/public Item\? optionalConcept \{ get; set; \}/);
+            file1.should.match(/public Item\[\] requiredConceptArray \{ get; set; \}/);
+            file1.should.match(/public Item\[\]\? optionalConceptArray \{ get; set; \}/);
+
+            // relationships (type name by default, not the identifier type)
+            file1.should.match(/public Item requiredRel \{ get; set; \}/);
+            file1.should.match(/public Item\? optionalRel \{ get; set; \}/);
+            file1.should.match(/public Item\[\] requiredRelArray \{ get; set; \}/);
+            file1.should.match(/public Item\[\]\? optionalRelArray \{ get; set; \}/);
         });
 
         it('should add identifier attributes for concepts with identified by', () => {
@@ -1586,6 +1638,27 @@ public class SampleModel : Concept {
             param.fileWriter.writeLine.withArgs(1, 'public Person[] Bob { get; set; }').calledOnce.should.be.ok;
         });
 
+        it('should write []? for a field that is both optional and an array', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('Bob');
+            mockField.getType.returns('Person');
+            mockField.isArray.returns(true);
+            mockField.isOptional.returns(true);
+
+            const mockModelManager = sinon.createStubInstance(ModelManager);
+            const mockModelFile = sinon.createStubInstance(ModelFile);
+            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+
+            mockModelManager.getType.returns(mockClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockField.getParent.returns(mockClassDeclaration);
+            csharpVisitor.visitField(mockField, param);
+            param.fileWriter.writeLine.withArgs(1, 'public Person[]? Bob { get; set; }').calledOnce.should.be.ok;
+        });
+
         it('should write a line for field name and type thats a map of <String, String>', () => {
             const mockField             = sinon.createStubInstance(Field);
             const getType               = sinon.stub();
@@ -1780,6 +1853,29 @@ public class SampleModel : Concept {
 
             param.fileWriter.writeLine.withArgs(1, 'public Person[] Bob { get; set; }').calledOnce.should.be.ok;
         });
+
+        it('should write []? for a relationship that is both optional and an array', () => {
+            let mockField = sinon.createStubInstance(Field);
+            mockField.isField.returns(true);
+            mockField.getName.returns('Bob');
+            mockField.getType.returns('Person');
+            mockField.isArray.returns(true);
+            mockField.isOptional.returns(true);
+            csharpVisitor.visitRelationship(mockField, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'public Person[]? Bob { get; set; }').calledOnce.should.be.ok;
+        });
+
+        it('should write ? for an optional relationship', () => {
+            let mockField = sinon.createStubInstance(Field);
+            mockField.isField.returns(true);
+            mockField.getName.returns('Bob');
+            mockField.getType.returns('Person');
+            mockField.isOptional.returns(true);
+            csharpVisitor.visitRelationship(mockField, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'public Person? Bob { get; set; }').calledOnce.should.be.ok;
+        });
     });
 
     describe('toCSharpType', () => {
@@ -1793,7 +1889,7 @@ public class SampleModel : Concept {
             csharpVisitor.toCSharpType('String').should.deep.equal('string');
         });
         it('should return number for Double', () => {
-            csharpVisitor.toCSharpType('Double').should.deep.equal('float');
+            csharpVisitor.toCSharpType('Double').should.deep.equal('double');
         });
         it('should return number for Long', () => {
             csharpVisitor.toCSharpType('Long').should.deep.equal('long');


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

- Double mapped to `float` instead of `double`; Concerto's 64-bit Double was mapped to C#'s 32-bit float. Fixed to `double`.

- `writeField` parameter order (array / nullableType swapped) `toCSharpProperty` takes (..., array, nullableType, ...). The call in `writeField` had them reversed, causing optional arrays to emit `string?[]` (array of nullable strings) instead of `string[]?` (optional array).

- `visitRelationship` never emitted `?` for optional relationships. The `isOptional()` check existed for fields but was missing entirely from `visitRelationship`. Optional relationships always emitted a non-nullable type.

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
