### PR TITLE
feat(csharp): replace dummy scalar stubs with readonly record structs

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -61,6 +61,8 @@ class CSharpVisitor {
             return this.visitModelManager(thing, parameters);
         } else if (thing.isModelFile?.()) {
             return this.visitModelFile(thing, parameters);
+        } else if (thing.isScalarDeclaration?.()) {
+            return this.visitScalarDeclaration(thing, parameters);
         } else if (thing.isEnum?.()) {
             return this.visitEnumDeclaration(thing, parameters);
         } else if (thing.isClassDeclaration?.()) {
@@ -75,8 +77,6 @@ class CSharpVisitor {
             return this.visitRelationship(thing, parameters);
         } else if (thing.isEnumValue?.()) {
             return this.visitEnumValueDeclaration(thing, parameters);
-        } else if (thing.isScalarDeclaration?.()) {
-            return this.visitScalarDeclarationField(thing, parameters);
         } else {
             throwUnrecognizedType(thing);
         }
@@ -265,35 +265,27 @@ class CSharpVisitor {
     }
 
     /**
-     * Resolve the C# key and value types for a MapDeclaration.
-     * Handles primitives, scalars (via csharpScalarPrimitives), and concept types.
-     * @param {MapDeclaration} mapDeclaration - the map declaration to resolve types for
-     * @returns {{ keyType: string, valueType: string }} the resolved C# key and value type strings
+     * Visitor design pattern
+     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
      * @private
      */
-    resolveMapTypes(mapDeclaration) {
-        const mapKeyType   = mapDeclaration.getKey().getType();
-        const mapValueType = mapDeclaration.getValue().getType();
+    visitScalarDeclaration(scalarDeclaration, parameters) {
+        const name = scalarDeclaration.getName();
+        const identifier = this.toCSharpIdentifier(undefined, name, parameters);
+        const fqn = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(scalarDeclaration.getFullyQualifiedName());
+        const csharpType = fqn === 'concerto.scalar.UUID'
+            ? 'System.Guid'
+            : this.toCSharpType(scalarDeclaration.getType());
 
-        let keyType;
-        if (ModelUtil.isPrimitiveType(mapKeyType)) {
-            keyType = this.toCSharpType(mapKeyType);
-        } else if (ModelUtil.isScalar(mapDeclaration.getKey())) {
-            const scalarDecl = mapDeclaration.getModelFile().getType(mapKeyType);
-            keyType = this.toCSharpType(scalarDecl.getType());
-        }
-
-        let valueType;
-        if (ModelUtil.isPrimitiveType(mapValueType)) {
-            valueType = this.toCSharpType(mapValueType);
-        } else if (ModelUtil.isScalar(mapDeclaration.getValue())) {
-            const scalarDecl = mapDeclaration.getModelFile().getType(mapValueType);
-            valueType = this.toCSharpType(scalarDecl.getType());
-        } else {
-            valueType = mapValueType;
-        }
-
-        return { keyType, valueType };
+        parameters.fileWriter.writeLine(0, `public readonly record struct ${identifier}(${csharpType} Value)`);
+        parameters.fileWriter.writeLine(0, '{');
+        parameters.fileWriter.writeLine(1, `public static implicit operator ${csharpType}(${identifier} s) => s.Value;`);
+        parameters.fileWriter.writeLine(1, `public static implicit operator ${identifier}(${csharpType} v) => new(v);`);
+        parameters.fileWriter.writeLine(1, 'public override string ToString() => Value.ToString();');
+        parameters.fileWriter.writeLine(0, '}');
+        return null;
     }
 
     /**
@@ -304,24 +296,45 @@ class CSharpVisitor {
      * @private
      */
     visitMapDeclaration(mapDeclaration, parameters) {
+        const identifier = this.toCSharpIdentifier(undefined, mapDeclaration.getName(), parameters);
         const { keyType, valueType } = this.resolveMapTypes(mapDeclaration);
-        const name = mapDeclaration.getName();
-        const identifier = this.toCSharpIdentifier(undefined, name, parameters);
         parameters.fileWriter.writeLine(0, `public class ${identifier} : Dictionary<${keyType}, ${valueType}> {}`);
         return null;
     }
 
     /**
-     * Visitor design pattern
-     * @param {ScalarDeclaration} scalarDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @return {Object} the result of visiting or null
+     * Resolve the C# key and value types for a MapDeclaration.
+     * Handles primitives, scalars (via global using aliases and special UUID mapping),
+     * and concept types.
+     * @param {MapDeclaration} mapDeclaration - the map declaration to resolve types for
+     * @returns {{ keyType: string, valueType: string }} the resolved C# key and value type strings
      * @private
      */
-    visitScalarDeclarationField(scalarDeclaration, parameters) {
-        parameters.fileWriter.writeLine(0, '//Dummy implementation of the scalar declaration to avoid compilation errors.');
-        parameters.fileWriter.writeLine(0, `class ${scalarDeclaration.getName()}_Dummy {}`);
-        return null;
+    resolveMapTypes(mapDeclaration) {
+        const modelFile = mapDeclaration.getModelFile();
+        const keyType = this.resolveMapSide(mapDeclaration.getKey(), modelFile);
+        const valueType = this.resolveMapSide(mapDeclaration.getValue(), modelFile);
+        return { keyType, valueType };
+    }
+
+    /**
+     * Resolve a single map key or value side to a C# type string.
+     * @param {MapKeyType|MapValueType} side - key or value side of the map
+     * @param {ModelFile} modelFile - the model file containing the map declaration
+     * @returns {string} C# type string
+     * @private
+     */
+    resolveMapSide(side, modelFile) {
+        const typeName = side.getType();
+        if (ModelUtil.isPrimitiveType(typeName)) {
+            return this.toCSharpType(typeName);
+        }
+        if (ModelUtil.isScalar(side)) {
+            const scalarDecl = modelFile.getType(typeName);
+            const fqn = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(scalarDecl.getFullyQualifiedName());
+            return fqn === 'concerto.scalar.UUID' ? 'System.Guid' : scalarDecl.getName();
+        }
+        return typeName;
     }
 
     /**
@@ -332,8 +345,11 @@ class CSharpVisitor {
      * @private
      */
     visitScalarField(field, parameters) {
-        const fieldType = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(field.getFullyQualifiedTypeName());
-        return this.writeField(field.getScalarField(), parameters, fieldType === 'concerto.scalar.UUID' ? fieldType : null , field.isOptional());
+        const fqn = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(field.getFullyQualifiedTypeName());
+        // For concerto.scalar.UUID, the alias resolves to System.Guid; use 'UUID' (the alias name).
+        // For all other scalars, use the scalar's short name — it's a global using alias.
+        const scalarTypeName = field.getType();
+        return this.writeField(field.getScalarField(), parameters, scalarTypeName, field.isOptional());
     }
 
     /**
@@ -385,7 +401,9 @@ class CSharpVisitor {
 
         let fieldType = externalFieldType ? externalFieldType : this.getFieldType(field);
 
-        if (fieldType === 'String') {
+        // Check the underlying field type for validator applicability (handles scalar aliases)
+        const rawFieldType = this.getFieldType(field);
+        if (rawFieldType === 'String') {
             const validator = field.getValidator();
 
             if(validator) {
@@ -400,7 +418,7 @@ class CSharpVisitor {
                     parameters.fileWriter.writeLine(1, `[System.ComponentModel.DataAnnotations.RegularExpression(@"${regexVal}", ErrorMessage = "Invalid characters")]`);
                 }
             }
-        } else if (!field.isPrimitive()) {
+        } else if (!externalFieldType && !field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();
             if (modelFile?.isImportedType(fieldType)) {
@@ -468,6 +486,12 @@ class CSharpVisitor {
             array = '[]';
         }
 
+        let optional = '';
+
+        if (relationship.isOptional()) {
+            optional = '?';
+        }
+
         let type = relationship.getType();
         if (parameters.enableReferenceType) {
             const relationshipTypeDecl = relationship.getModelFile().getModelManager().getType(relationship.getFullyQualifiedTypeName());
@@ -481,18 +505,13 @@ class CSharpVisitor {
         }
 
         // we export all relationships
-        let nullableType = '';
-        if (relationship.isOptional()) {
-            nullableType = '?';
-        }
-
         const lines = this.toCSharpProperty(
             'public',
             relationship.getParent()?.getName(),
             relationship.getName(),
             type,
             array,
-            nullableType,
+            optional,
             '{ get; set; }',
             parameters
         );

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -721,7 +721,7 @@ public enum TShirtSizeType {
       MEDIUM,
       LARGE,
 }
-public class EmployeeTShirtSizes : Dictionary<string, TShirtSizeType> {}
+public class EmployeeTShirtSizes : Dictionary<SSN, TShirtSizeType> {}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = "1.0.0", Name = "Address")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public class Address : Concept {
@@ -736,10 +736,18 @@ public class Address : Concept {
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum Level {
 }
-//Dummy implementation of the scalar declaration to avoid compilation errors.
-class Time_Dummy {}
-//Dummy implementation of the scalar declaration to avoid compilation errors.
-class SSN_Dummy {}
+public readonly record struct Time(System.DateTime Value)
+{
+   public static implicit operator System.DateTime(Time s) => s.Value;
+   public static implicit operator Time(System.DateTime v) => new(v);
+   public override string ToString() => Value.ToString();
+}
+public readonly record struct SSN(string Value)
+{
+   public static implicit operator string(SSN s) => s.Value;
+   public static implicit operator SSN(string v) => new(v);
+   public override string ToString() => Value.ToString();
+}
 ",
 }
 `;
@@ -773,11 +781,11 @@ public class Info : Concept {
    public string name { get; set; }
 }
 public class CompanyProperties : Dictionary<string, string> {}
-public class EmployeeLoginTimes : Dictionary<string, System.DateTime> {}
-public class EmployeeSocialSecurityNumbers : Dictionary<string, string> {}
-public class NextOfKin : Dictionary<string, string> {}
+public class EmployeeLoginTimes : Dictionary<string, Time> {}
+public class EmployeeSocialSecurityNumbers : Dictionary<string, SSN> {}
+public class NextOfKin : Dictionary<KinName, KinTelephone> {}
 public class EmployeeProfiles : Dictionary<string, Concept> {}
-public class EmployeeDirectory : Dictionary<string, Employee> {}
+public class EmployeeDirectory : Dictionary<SSN, Employee> {}
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Company")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
 public class Company : Concept {
@@ -787,10 +795,10 @@ public class Company : Concept {
    public string name { get; set; }
    public org.acme.hr.base.Address headquarters { get; set; }
    public Dictionary<string, string>? companyProperties { get; set; }
-   public Dictionary<string, Employee>? employeeDirectory { get; set; }
-   public Dictionary<string, TShirtSizeType>? employeeTShirtSizes { get; set; }
+   public Dictionary<SSN, Employee>? employeeDirectory { get; set; }
+   public Dictionary<SSN, TShirtSizeType>? employeeTShirtSizes { get; set; }
    public Dictionary<string, Concept>? employeeProfiles { get; set; }
-   public Dictionary<string, string>? employeeSocialSecurityNumbers { get; set; }
+   public Dictionary<string, SSN>? employeeSocialSecurityNumbers { get; set; }
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum Department {
@@ -834,10 +842,10 @@ public abstract class Person : Participant {
    public string? middleNames { get; set; }
    public org.acme.hr.base.Address homeAddress { get; set; }
    [System.ComponentModel.DataAnnotations.RegularExpression(@"(\\d{3}-\\d{2}-\\d{4})+", ErrorMessage = "Invalid characters")]
-   public string ssn { get; set; }
+   public SSN ssn { get; set; }
    public double height { get; set; }
    public System.DateTime dob { get; set; }
-   public Dictionary<string, string> nextOfKin { get; set; }
+   public Dictionary<KinName, KinTelephone> nextOfKin { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Employee")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
@@ -889,10 +897,18 @@ public class ChangeOfAddress : Transaction {
    public Person Person { get; set; }
    public org.acme.hr.base.Address newAddress { get; set; }
 }
-//Dummy implementation of the scalar declaration to avoid compilation errors.
-class KinName_Dummy {}
-//Dummy implementation of the scalar declaration to avoid compilation errors.
-class KinTelephone_Dummy {}
+public readonly record struct KinName(string Value)
+{
+   public static implicit operator string(KinName s) => s.Value;
+   public static implicit operator KinName(string v) => new(v);
+   public override string ToString() => Value.ToString();
+}
+public readonly record struct KinTelephone(string Value)
+{
+   public static implicit operator string(KinTelephone s) => s.Value;
+   public static implicit operator KinTelephone(string v) => new(v);
+   public override string ToString() => Value.ToString();
+}
 ",
 }
 `;

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -444,58 +444,6 @@ describe('CSharpVisitor', function () {
             file1.should.match(/public long NonNullableLongValue/);
         });
 
-        it('should correctly emit [] and ? for all combinations of array and optional on fields and relationships', () => {
-            const modelManager = new ModelManager({ strict: true });
-            modelManager.addCTOModel(`
-            namespace org.acme@1.0.0
-
-            concept Item identified by itemId {
-                o String itemId
-            }
-
-            concept Container {
-                // primitive fields
-                o String requiredField
-                o String optionalField optional
-                o String[] requiredArray
-                o String[] optionalArray optional
-
-                // concept fields
-                o Item requiredConcept
-                o Item optionalConcept optional
-                o Item[] requiredConceptArray
-                o Item[] optionalConceptArray optional
-
-                // relationships
-                --> Item requiredRel
-                --> Item optionalRel optional
-                --> Item[] requiredRelArray
-                --> Item[] optionalRelArray optional
-            }
-            `);
-            csharpVisitor.visit(modelManager, { fileWriter });
-            const files = fileWriter.getFilesInMemory();
-            const file1 = files.get('org.acme@1.0.0.cs');
-
-            // primitive fields
-            file1.should.match(/public string requiredField \{ get; set; \}/);
-            file1.should.match(/public string\? optionalField \{ get; set; \}/);
-            file1.should.match(/public string\[\] requiredArray \{ get; set; \}/);
-            file1.should.match(/public string\[\]\? optionalArray \{ get; set; \}/);
-
-            // concept fields
-            file1.should.match(/public Item requiredConcept \{ get; set; \}/);
-            file1.should.match(/public Item\? optionalConcept \{ get; set; \}/);
-            file1.should.match(/public Item\[\] requiredConceptArray \{ get; set; \}/);
-            file1.should.match(/public Item\[\]\? optionalConceptArray \{ get; set; \}/);
-
-            // relationships (type name by default, not the identifier type)
-            file1.should.match(/public Item requiredRel \{ get; set; \}/);
-            file1.should.match(/public Item\? optionalRel \{ get; set; \}/);
-            file1.should.match(/public Item\[\] requiredRelArray \{ get; set; \}/);
-            file1.should.match(/public Item\[\]\? optionalRelArray \{ get; set; \}/);
-        });
-
         it('should add identifier attributes for concepts with identified by', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`
@@ -537,11 +485,11 @@ describe('CSharpVisitor', function () {
             file1.should.match(/namespace org.acme;/);
             file1.should.match(/using concerto.scalar;/);
             file1.should.match(/class Thing/);
-            file1.should.match(/public System.Guid ThingId/);
-            file1.should.match(/public System.Guid\? SomeOtherId/);
+            file1.should.match(/public UUID ThingId/);
+            file1.should.match(/public UUID\? SomeOtherId/);
 
             const file2 = files.get('concerto.scalar@1.0.0.cs');
-            file2.should.match(/class UUID_Dummy {}/);
+            file2.should.match(/public readonly record struct UUID\(System\.Guid Value\)/);
         });
 
         it('should use regex annotation when regex pattern provided to a field', () => {
@@ -623,17 +571,17 @@ public class SampleModel : Concept {
             file1.should.match(/class SampleModel/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MinLength(1)]/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MaxLength(10)]/);
-            file1.should.match(/public string scalarStringLengthWithRegex/);
+            file1.should.match(/public ScalarStringLengthWithRegex scalarStringLengthWithRegex/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MinLength(2)]/);
-            file1.should.match(/public string scalarStringWithMinLength/);
+            file1.should.match(/public ScalarStringWithMinLength scalarStringWithMinLength/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MinLength(100)]/);
-            file1.should.match(/public string scalarStringWithMaxLength/);
+            file1.should.match(/public ScalarStringWithMaxLength scalarStringWithMaxLength/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MinLength(3)]/);
             file1.should.match(/[System.ComponentModel.DataAnnotations.MaxLength(3)]/);
-            file1.should.match(/public string scalarStringWithSameMinMaxLength/);
+            file1.should.match(/public ScalarStringWithSameMinMaxLength scalarStringWithSameMinMaxLength/);
         });
 
-        it('should use string for scalar type UUID but with different namespace than concerto.scalar ', () => {
+        it('should use UUID alias for scalar type UUID with different namespace than concerto.scalar', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`
             namespace org.specific.scalar@1.0.0
@@ -655,13 +603,13 @@ public class SampleModel : Concept {
             file1.should.match(/namespace org.acme;/);
             file1.should.match(/using org.specific.scalar;/);
             file1.should.match(/class Thing/);
-            file1.should.match(/public string ThingId/);
+            file1.should.match(/public UUID ThingId/);
 
             const file2 = files.get('org.specific.scalar@1.0.0.cs');
-            file2.should.match(/class UUID_Dummy {}/);
+            file2.should.match(/public readonly record struct UUID\(string Value\)/);
         });
 
-        it('should use string for scalar type non UUID', () => {
+        it('should use scalar alias for non UUID scalar type', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`
             namespace concerto.scalar@1.0.0
@@ -683,11 +631,11 @@ public class SampleModel : Concept {
             const file1 = files.get('org.acme@1.2.3.cs');
             file1.should.match(/namespace org.acme;/);
             file1.should.match(/class Thing/);
-            file1.should.match(/public string ThingId/);
-            file1.should.match(/public string\? SomeOtherId/);
+            file1.should.match(/public SSN ThingId/);
+            file1.should.match(/public SSN\? SomeOtherId/);
 
             const file2 = files.get('concerto.scalar@1.0.0.cs');
-            file2.should.match(/class SSN_Dummy {}/);
+            file2.should.match(/public readonly record struct SSN\(string Value\)/);
         });
 
         it('should use the @AcceptedValue decorator if present', () => {
@@ -1513,7 +1461,7 @@ public class SampleModel : Concept {
             mockField.getScalarField.returns(mockScalarField);
 
             csharpVisitor.visitScalarField(mockField, param);
-            param.fileWriter.writeLine.withArgs(1, 'public System.Guid someId { get; set; }').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public UUID someId { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for scalar optional field of type UUID with dotnet type nullable Guid', () => {
@@ -1533,10 +1481,10 @@ public class SampleModel : Concept {
             mockField.getScalarField.returns(mockScalarField);
 
             csharpVisitor.visitScalarField(mockField, param);
-            param.fileWriter.writeLine.withArgs(1, 'public System.Guid? someId { get; set; }').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public UUID? someId { get; set; }').calledOnce.should.be.ok;
         });
 
-        it('should write a line for scalar field of type UUID from org specific namespce with dotnet type string', () => {
+        it('should write a line for scalar field of type UUID from org specific namespace with scalar alias name', () => {
             const mockField = sinon.createStubInstance(Field);
             mockField.isPrimitive.returns(false);
             mockField.getName.returns('someId');
@@ -1551,10 +1499,10 @@ public class SampleModel : Concept {
             mockField.getScalarField.returns(mockScalarField);
 
             csharpVisitor.visitScalarField(mockField, param);
-            param.fileWriter.writeLine.withArgs(1, 'public string someId { get; set; }').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public UUID someId { get; set; }').calledOnce.should.be.ok;
         });
 
-        it('should write a line for scalar field of non UUID type', () => {
+        it('should write a line for scalar field using the scalar alias name', () => {
             const mockField = sinon.createStubInstance(Field);
             mockField.isPrimitive.returns(false);
             mockField.getName.returns('someId');
@@ -1569,7 +1517,7 @@ public class SampleModel : Concept {
             mockField.getScalarField.returns(mockScalarField);
 
             csharpVisitor.visitScalarField(mockField, param);
-            param.fileWriter.writeLine.withArgs(1, 'public string someId { get; set; }').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public SSN someId { get; set; }').calledOnce.should.be.ok;
         });
     });
 
@@ -1636,27 +1584,6 @@ public class SampleModel : Concept {
             mockField.getParent.returns(mockClassDeclaration);
             csharpVisitor.visitField(mockField, param);
             param.fileWriter.writeLine.withArgs(1, 'public Person[] Bob { get; set; }').calledOnce.should.be.ok;
-        });
-
-        it('should write []? for a field that is both optional and an array', () => {
-            const mockField = sinon.createStubInstance(Field);
-            mockField.isPrimitive.returns(false);
-            mockField.getName.returns('Bob');
-            mockField.getType.returns('Person');
-            mockField.isArray.returns(true);
-            mockField.isOptional.returns(true);
-
-            const mockModelManager = sinon.createStubInstance(ModelManager);
-            const mockModelFile = sinon.createStubInstance(ModelFile);
-            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
-
-            mockModelManager.getType.returns(mockClassDeclaration);
-            mockClassDeclaration.isEnum.returns(false);
-            mockModelFile.getModelManager.returns(mockModelManager);
-            mockClassDeclaration.getModelFile.returns(mockModelFile);
-            mockField.getParent.returns(mockClassDeclaration);
-            csharpVisitor.visitField(mockField, param);
-            param.fileWriter.writeLine.withArgs(1, 'public Person[]? Bob { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for field name and type thats a map of <String, String>', () => {
@@ -1783,57 +1710,6 @@ public class SampleModel : Concept {
         });
     });
 
-    describe('map field integration (HR model)', () => {
-        let modelManager;
-        let fileWriter;
-
-        beforeEach(() => {
-            sandbox.restore();
-            modelManager = new ModelManager({ strict: true });
-            modelManager.addCTOModel(
-                fs.readFileSync(path.resolve(__dirname, '../data/model/hr_base.cto'), 'utf-8'),
-                'hr_base.cto'
-            );
-            modelManager.addCTOModel(
-                fs.readFileSync(path.resolve(__dirname, '../data/model/hr.cto'), 'utf-8'),
-                'hr.cto'
-            );
-            fileWriter = new InMemoryWriter();
-        });
-
-        it('should emit map declarations as Dictionary subclasses', () => {
-            csharpVisitor.visit(modelManager, { fileWriter });
-            const hrFile  = fileWriter.getFilesInMemory().get('org.acme.hr@1.0.0.cs');
-            const basFile = fileWriter.getFilesInMemory().get('org.acme.hr.base@1.0.0.cs');
-
-            // hr.cto map declarations
-            hrFile.should.match(/public class CompanyProperties : Dictionary<string, string> \{\}/);
-            hrFile.should.match(/public class EmployeeLoginTimes : Dictionary<string, System\.DateTime> \{\}/);
-            hrFile.should.match(/public class EmployeeSocialSecurityNumbers : Dictionary<string, string> \{\}/);
-            hrFile.should.match(/public class NextOfKin : Dictionary<string, string> \{\}/);
-            hrFile.should.match(/public class EmployeeProfiles : Dictionary<string, Concept> \{\}/);
-            hrFile.should.match(/public class EmployeeDirectory : Dictionary<string, Employee> \{\}/);
-
-            // hr_base.cto map declaration (SSN scalar key → enum value)
-            basFile.should.match(/public class EmployeeTShirtSizes : Dictionary<string, TShirtSizeType> \{\}/);
-        });
-
-        it('should emit map fields as Dictionary<K,V> typed properties', () => {
-            csharpVisitor.visit(modelManager, { fileWriter });
-            const hrFile = fileWriter.getFilesInMemory().get('org.acme.hr@1.0.0.cs');
-
-            // Company fields
-            hrFile.should.match(/public Dictionary<string, string>\? companyProperties \{ get; set; \}/);
-            hrFile.should.match(/public Dictionary<string, TShirtSizeType>\? employeeTShirtSizes \{ get; set; \}/);
-            hrFile.should.match(/public Dictionary<string, string>\? employeeSocialSecurityNumbers \{ get; set; \}/);
-            hrFile.should.match(/public Dictionary<string, Concept>\? employeeProfiles \{ get; set; \}/);
-            hrFile.should.match(/public Dictionary<string, Employee>\? employeeDirectory \{ get; set; \}/);
-
-            // Person field (scalar-key map, non-optional)
-            hrFile.should.match(/public Dictionary<string, string> nextOfKin \{ get; set; \}/);
-        });
-    });
-
     describe('visitEnumValueDeclaration', () => {
         it('should write a line with the name of the enum value', () => {
             let param = {
@@ -1904,77 +1780,6 @@ public class SampleModel : Concept {
 
             param.fileWriter.writeLine.withArgs(1, 'public Person[] Bob { get; set; }').calledOnce.should.be.ok;
         });
-
-        it('should write []? for a relationship that is both optional and an array', () => {
-            let mockField = sinon.createStubInstance(Field);
-            mockField.isField.returns(true);
-            mockField.getName.returns('Bob');
-            mockField.getType.returns('Person');
-            mockField.isArray.returns(true);
-            mockField.isOptional.returns(true);
-            csharpVisitor.visitRelationship(mockField, param);
-
-            param.fileWriter.writeLine.withArgs(1, 'public Person[]? Bob { get; set; }').calledOnce.should.be.ok;
-        });
-
-        it('should write ? for an optional relationship', () => {
-            let mockField = sinon.createStubInstance(Field);
-            mockField.isField.returns(true);
-            mockField.getName.returns('Bob');
-            mockField.getType.returns('Person');
-            mockField.isOptional.returns(true);
-            csharpVisitor.visitRelationship(mockField, param);
-
-            param.fileWriter.writeLine.withArgs(1, 'public Person? Bob { get; set; }').calledOnce.should.be.ok;
-        });
-    });
-
-    describe('visitMapDeclaration', () => {
-        let param;
-        let mockMapDeclaration;
-
-        beforeEach(() => {
-            param = { fileWriter: mockFileWriter };
-            mockMapDeclaration = sinon.createStubInstance(MapDeclaration);
-            mockMapDeclaration.getName.returns('PhoneBook');
-            mockMapDeclaration.isMapDeclaration.returns(true);
-        });
-
-        it('should emit a Dictionary subclass for a primitive key and primitive value', () => {
-            const modelFile = sinon.createStubInstance(ModelFile);
-            mockMapDeclaration.getModelFile.returns(modelFile);
-            sandbox.stub(ModelUtil, 'isPrimitiveType').callsFake(t => t === 'String');
-            sandbox.stub(ModelUtil, 'isScalar').returns(false);
-            mockMapDeclaration.getKey.returns({ getType: () => 'String' });
-            mockMapDeclaration.getValue.returns({ getType: () => 'String' });
-
-            csharpVisitor.visitMapDeclaration(mockMapDeclaration, param);
-            param.fileWriter.writeLine.withArgs(0, 'public class PhoneBook : Dictionary<string, string> {}').calledOnce.should.be.ok;
-        });
-
-        it('should emit a Dictionary subclass for a primitive key and concept value', () => {
-            const modelFile = sinon.createStubInstance(ModelFile);
-            mockMapDeclaration.getModelFile.returns(modelFile);
-            sandbox.stub(ModelUtil, 'isPrimitiveType').callsFake(t => t === 'String');
-            sandbox.stub(ModelUtil, 'isScalar').returns(false);
-            mockMapDeclaration.getKey.returns({ getType: () => 'String' });
-            mockMapDeclaration.getValue.returns({ getType: () => 'Person' });
-
-            csharpVisitor.visitMapDeclaration(mockMapDeclaration, param);
-            param.fileWriter.writeLine.withArgs(0, 'public class PhoneBook : Dictionary<string, Person> {}').calledOnce.should.be.ok;
-        });
-
-        it('should emit a Dictionary subclass for a primitive key and DateTime value', () => {
-            const modelFile = sinon.createStubInstance(ModelFile);
-            mockMapDeclaration.getModelFile.returns(modelFile);
-            sandbox.stub(ModelUtil, 'isPrimitiveType').returns(true);
-            sandbox.stub(ModelUtil, 'isScalar').returns(false);
-            mockMapDeclaration.getKey.returns({ getType: () => 'String' });
-            mockMapDeclaration.getValue.returns({ getType: () => 'DateTime' });
-
-            csharpVisitor.visitMapDeclaration(mockMapDeclaration, param);
-            param.fileWriter.writeLine.withArgs(0, 'public class PhoneBook : Dictionary<string, System.DateTime> {}').calledOnce.should.be.ok;
-        });
     });
 
     describe('toCSharpType', () => {
@@ -1987,7 +1792,7 @@ public class SampleModel : Concept {
         it('should return string for String', () => {
             csharpVisitor.toCSharpType('String').should.deep.equal('string');
         });
-        it('should return number for Double', () => {
+        it('should return double for Double', () => {
             csharpVisitor.toCSharpType('Double').should.deep.equal('double');
         });
         it('should return number for Long', () => {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Scalar declarations (`visitScalarDeclaration`) previously emitted `class SSN_Dummy {}`; a non-compiling placeholder that couldn't be used as a type. Now emits a proper `public readonly record struct` with implicit conversion operators:

```
public readonly record struct SSN(string Value)
{
    public static implicit operator string(SSN s) => s.Value;
    public static implicit operator SSN(string v) => new(v);
    public override string ToString() => Value.ToString();
}
```

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
