### PR TITLE
feat(csharp): idiomatic C# code generation for scalar types, validators, and defaults

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -382,6 +382,23 @@ class CSharpVisitor {
     }
 
     /**
+     * Returns true if the map key/value side is a scalar that declares validators.
+     * Used to decide whether to emit [ValidateComplexType] on the map property.
+     * @param {MapKeyType|MapValueType} side - key or value side of the map
+     * @param {ModelFile} modelFile - the model file containing the map declaration
+     * @returns {boolean} - true if the map side is a scalar with validators, false otherwise
+     * @private
+     */
+    mapSideHasValidators(side, modelFile) {
+        const typeName = side.getType();
+        if (!ModelUtil.isPrimitiveType(typeName) && ModelUtil.isScalar(side)) {
+            const scalarDecl = modelFile.getType(typeName);
+            return !!scalarDecl?.getValidator?.();
+        }
+        return false;
+    }
+
+    /**
      * Visitor design pattern
      * @param {Field} field - the object being visited
      * @param {Object} parameters  - the parameter
@@ -425,6 +442,10 @@ class CSharpVisitor {
             const mapDeclaration = field.getModelFile().getType(field.getType());
             const { keyType, valueType } = this.resolveMapTypes(mapDeclaration);
             const nullable = field.isOptional() ? '?' : '';
+            if (this.mapSideHasValidators(mapDeclaration.getKey(), mapDeclaration.getModelFile()) ||
+                this.mapSideHasValidators(mapDeclaration.getValue(), mapDeclaration.getModelFile())) {
+                parameters.fileWriter.writeLine(1, '[System.ComponentModel.DataAnnotations.ValidateComplexType]');
+            }
             parameters.fileWriter.writeLine(1, `public Dictionary<${keyType}, ${valueType}>${nullable} ${field.getName()} { get; set; }`);
             return null;
         }

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -418,6 +418,21 @@ class CSharpVisitor {
                     parameters.fileWriter.writeLine(1, `[System.ComponentModel.DataAnnotations.RegularExpression(@"${regexVal}", ErrorMessage = "Invalid characters")]`);
                 }
             }
+        } else if (['Integer', 'Long', 'Double'].includes(rawFieldType)) {
+            const validator = field.getValidator();
+            if (validator) {
+                const lower = validator.getLowerBound();
+                const upper = validator.getUpperBound();
+                if (lower !== null || upper !== null) {
+                    const csTypeMap = { Integer: 'int', Long: 'long', Double: 'double' };
+                    const defaultMin = { Integer: '-2147483648', Long: '-9223372036854775808', Double: '-1.7976931348623157E+308' };
+                    const defaultMax = { Integer: '2147483647', Long: '9223372036854775807', Double: '1.7976931348623157E+308' };
+                    const csType = csTypeMap[rawFieldType];
+                    const lo = lower !== null ? String(lower) : defaultMin[rawFieldType];
+                    const hi = upper !== null ? String(upper) : defaultMax[rawFieldType];
+                    parameters.fileWriter.writeLine(1, `[System.ComponentModel.DataAnnotations.Range(typeof(${csType}), "${lo}", "${hi}")]`);
+                }
+            }
         } else if (!externalFieldType && !field.isPrimitive()) {
             let fqn = this.getDotNetNamespaceOfType(field.getFullyQualifiedTypeName(), field.getParent(), parameters);
             const modelFile = field.getModelFile();

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -122,6 +122,10 @@ class CSharpVisitor {
 
         parameters.fileWriter.writeLine(0, `namespace ${dotNetNamespace};`);
 
+        if (modelFile.getAllDeclarations().some(d => d.isMapDeclaration?.())) {
+            parameters.fileWriter.writeLine(0, 'using System.Collections.Generic;');
+        }
+
         modelFile.getImports()
             .map(importString => ModelUtil.getNamespace(importString))
             .filter(namespace => namespace !== modelFile.getNamespace()) // Skip own namespace.
@@ -279,11 +283,24 @@ class CSharpVisitor {
         const csharpType = fqn === 'concerto.scalar.UUID'
             ? 'System.Guid'
             : this.toCSharpType(scalarDeclaration.getType());
-
         const validatorLines = this.buildScalarValidatorLines(scalarDeclaration);
         const converterName = `${identifier}JsonConverter`;
+        const useNewtonsoft = !!parameters.useNewtonsoftJson;
 
-        parameters.fileWriter.writeLine(0, `[System.Text.Json.Serialization.JsonConverter(typeof(${converterName}))]`);
+        const converterAttr = useNewtonsoft
+            ? `[Newtonsoft.Json.JsonConverter(typeof(${converterName}))]`
+            : `[System.Text.Json.Serialization.JsonConverter(typeof(${converterName}))]`;
+        const converterBase = useNewtonsoft
+            ? `Newtonsoft.Json.JsonConverter<${identifier}>`
+            : `System.Text.Json.Serialization.JsonConverter<${identifier}>`;
+        const readSig = useNewtonsoft
+            ? `public override ${identifier} ReadJson(Newtonsoft.Json.JsonReader r, System.Type t, ${identifier} existing, bool hasExisting, Newtonsoft.Json.JsonSerializer s)`
+            : `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`;
+        const writeSig = useNewtonsoft
+            ? `public override void WriteJson(Newtonsoft.Json.JsonWriter w, ${identifier} v, Newtonsoft.Json.JsonSerializer s)`
+            : `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`;
+
+        parameters.fileWriter.writeLine(0, converterAttr);
         parameters.fileWriter.writeLine(0, `public readonly record struct ${identifier}(${csharpType} Value)`);
         parameters.fileWriter.writeLine(0, '{');
         if (validatorLines.length > 0) {
@@ -295,38 +312,39 @@ class CSharpVisitor {
         parameters.fileWriter.writeLine(1, 'public override string ToString() => Value.ToString();');
         parameters.fileWriter.writeLine(0, '}');
 
-        // Companion JsonConverter so System.Text.Json reads/writes the struct as a bare scalar value
-        parameters.fileWriter.writeLine(0, `public class ${converterName} : System.Text.Json.Serialization.JsonConverter<${identifier}>`);
-        parameters.fileWriter.writeLine(0, '{');
+        // Companion converter — one per scalar, flavoured by the active serializer
+        let readExpr, writeExpr;
         if (csharpType === 'System.Guid') {
-            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> new(r.GetGuid());');
-            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value.ToString());');
+            readExpr = useNewtonsoft ? 'System.Guid.Parse((string)r.Value!)' : 'r.GetGuid()';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value.ToString())' : 'w.WriteStringValue(v.Value.ToString())';
         } else if (csharpType === 'string') {
-            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> new(r.GetString()!);');
-            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value);');
+            readExpr = useNewtonsoft ? '(string)r.Value!' : 'r.GetString()!';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value)' : 'w.WriteStringValue(v.Value)';
         } else if (csharpType === 'bool') {
-            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> new(r.GetBoolean());');
-            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> w.WriteBooleanValue(v.Value);');
-        } else if (['int', 'long', 'double'].includes(csharpType)) {
-            const getMethod = { int: 'GetInt32', long: 'GetInt64', double: 'GetDouble' }[csharpType];
-            const writeMethod = { int: 'WriteNumberValue', long: 'WriteNumberValue', double: 'WriteNumberValue' }[csharpType];
-            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, `=> new(r.${getMethod}());`);
-            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, `=> w.${writeMethod}(v.Value);`);
+            readExpr = useNewtonsoft ? '(bool)r.Value!' : 'r.GetBoolean()';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value)' : 'w.WriteBooleanValue(v.Value)';
+        } else if (csharpType === 'int') {
+            readExpr = useNewtonsoft ? 'System.Convert.ToInt32(r.Value)' : 'r.GetInt32()';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value)' : 'w.WriteNumberValue(v.Value)';
+        } else if (csharpType === 'long') {
+            readExpr = useNewtonsoft ? 'System.Convert.ToInt64(r.Value)' : 'r.GetInt64()';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value)' : 'w.WriteNumberValue(v.Value)';
+        } else if (csharpType === 'double') {
+            readExpr = useNewtonsoft ? 'System.Convert.ToDouble(r.Value)' : 'r.GetDouble()';
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value)' : 'w.WriteNumberValue(v.Value)';
         } else {
-            // fallback: serialize as string via ToString
-            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, `=> new((${csharpType})System.Convert.ChangeType(r.GetString()!, typeof(${csharpType})));`);
-            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
-            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value.ToString()!);');
+            readExpr = useNewtonsoft
+                ? `(${csharpType})System.Convert.ChangeType((string)r.Value!, typeof(${csharpType}))`
+                : `(${csharpType})System.Convert.ChangeType(r.GetString()!, typeof(${csharpType}))`;
+            writeExpr = useNewtonsoft ? 'w.WriteValue(v.Value.ToString()!)' : 'w.WriteStringValue(v.Value.ToString()!)';
         }
+
+        parameters.fileWriter.writeLine(0, `public class ${converterName} : ${converterBase}`);
+        parameters.fileWriter.writeLine(0, '{');
+        parameters.fileWriter.writeLine(1, readSig);
+        parameters.fileWriter.writeLine(2, `=> new(${readExpr});`);
+        parameters.fileWriter.writeLine(1, writeSig);
+        parameters.fileWriter.writeLine(2, `=> ${writeExpr};`);
         parameters.fileWriter.writeLine(0, '}');
 
         return null;
@@ -378,7 +396,7 @@ class CSharpVisitor {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         const identifier = this.toCSharpIdentifier(undefined, mapDeclaration.getName(), parameters);
-        const { keyType, valueType } = this.resolveMapTypes(mapDeclaration);
+        const { keyType, valueType } = this.resolveMapTypes(mapDeclaration, parameters);
         parameters.fileWriter.writeLine(0, `public class ${identifier} : Dictionary<${keyType}, ${valueType}> {}`);
         return null;
     }
@@ -388,13 +406,14 @@ class CSharpVisitor {
      * Handles primitives, scalars (via global using aliases and special UUID mapping),
      * and concept types.
      * @param {MapDeclaration} mapDeclaration - the map declaration to resolve types for
+     * @param {Object} parameters - the visitor parameters (used for PascalCase conversion)
      * @returns {{ keyType: string, valueType: string }} the resolved C# key and value type strings
      * @private
      */
-    resolveMapTypes(mapDeclaration) {
+    resolveMapTypes(mapDeclaration, parameters) {
         const modelFile = mapDeclaration.getModelFile();
-        const keyType = this.resolveMapSide(mapDeclaration.getKey(), modelFile);
-        const valueType = this.resolveMapSide(mapDeclaration.getValue(), modelFile);
+        const keyType = this.resolveMapSide(mapDeclaration.getKey(), modelFile, parameters);
+        const valueType = this.resolveMapSide(mapDeclaration.getValue(), modelFile, parameters);
         return { keyType, valueType };
     }
 
@@ -402,10 +421,11 @@ class CSharpVisitor {
      * Resolve a single map key or value side to a C# type string.
      * @param {MapKeyType|MapValueType} side - key or value side of the map
      * @param {ModelFile} modelFile - the model file containing the map declaration
-     * @returns {string} C# type string
+     * @param {Object} parameters - the visitor parameters
+     * @returns {string} - the resolved type string for the map side
      * @private
      */
-    resolveMapSide(side, modelFile) {
+    resolveMapSide(side, modelFile, parameters) {
         const typeName = side.getType();
         if (ModelUtil.isPrimitiveType(typeName)) {
             return this.toCSharpType(typeName);
@@ -413,9 +433,9 @@ class CSharpVisitor {
         if (ModelUtil.isScalar(side)) {
             const scalarDecl = modelFile.getType(typeName);
             const fqn = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(scalarDecl.getFullyQualifiedName());
-            return fqn === 'concerto.scalar.UUID' ? 'System.Guid' : scalarDecl.getName();
+            return fqn === 'concerto.scalar.UUID' ? 'System.Guid' : this.toCSharpIdentifier(undefined, scalarDecl.getName(), parameters);
         }
-        return typeName;
+        return this.toCSharpIdentifier(undefined, typeName, parameters);
     }
 
     /**
@@ -482,13 +502,11 @@ class CSharpVisitor {
         // write Map field
         if (ModelUtil.isMap?.(field)) {
             const mapDeclaration = field.getModelFile().getType(field.getType());
-            const { keyType, valueType } = this.resolveMapTypes(mapDeclaration);
+            const { keyType, valueType } = this.resolveMapTypes(mapDeclaration, parameters);
             const nullable = field.isOptional() ? '?' : '';
-            if (this.mapSideHasValidators(mapDeclaration.getKey(), mapDeclaration.getModelFile()) ||
-                this.mapSideHasValidators(mapDeclaration.getValue(), mapDeclaration.getModelFile())) {
-                parameters.fileWriter.writeLine(1, '[System.ComponentModel.DataAnnotations.ValidateComplexType]');
-            }
-            parameters.fileWriter.writeLine(1, `public Dictionary<${keyType}, ${valueType}>${nullable} ${field.getName()} { get; set; }`);
+            const resolvedType = `Dictionary<${keyType}, ${valueType}>`;
+            const lines = this.toCSharpProperty('public', field.getParent()?.getName(), field.getName(), null, '', nullable, '{ get; set; }', parameters, resolvedType);
+            lines.forEach(line => parameters.fileWriter.writeLine(1, line));
             return null;
         }
 
@@ -676,11 +694,12 @@ class CSharpVisitor {
      * @param {string} nullableType the nullable expression ?
      * @param {string} getset the getter and setter declaration
      * @param {Object} [parameters]  - the parameter
+     * @param {string} [resolvedType] - pre-built C# type string; when provided, skips toCSharpType
      * @returns {string} the property declaration
      */
-    toCSharpProperty(access, parentName, propertyName, propertyType, array, nullableType, getset, parameters) {
+    toCSharpProperty(access, parentName, propertyName, propertyType, array, nullableType, getset, parameters, resolvedType = undefined) {
         const identifier = this.toCSharpIdentifier(parentName, propertyName, parameters);
-        const type = this.toCSharpType(propertyType, parameters);
+        const type = resolvedType ?? this.toCSharpType(propertyType, parameters);
 
         let lines = [];
 

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -1,3 +1,4 @@
+/* eslint-disable eqeqeq */
 /* eslint-disable no-unreachable */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -279,13 +280,56 @@ class CSharpVisitor {
             ? 'System.Guid'
             : this.toCSharpType(scalarDeclaration.getType());
 
+        const validatorLines = this.buildScalarValidatorLines(scalarDeclaration);
+
         parameters.fileWriter.writeLine(0, `public readonly record struct ${identifier}(${csharpType} Value)`);
         parameters.fileWriter.writeLine(0, '{');
+        if (validatorLines.length > 0) {
+            validatorLines.forEach(line => parameters.fileWriter.writeLine(1, line));
+            parameters.fileWriter.writeLine(1, `public ${csharpType} Value { get; init; } = Value;`);
+        }
         parameters.fileWriter.writeLine(1, `public static implicit operator ${csharpType}(${identifier} s) => s.Value;`);
         parameters.fileWriter.writeLine(1, `public static implicit operator ${identifier}(${csharpType} v) => new(v);`);
         parameters.fileWriter.writeLine(1, 'public override string ToString() => Value.ToString();');
         parameters.fileWriter.writeLine(0, '}');
         return null;
+    }
+
+    /**
+     * Build the DataAnnotations attribute lines for a scalar declaration's validator.
+     * @param {ScalarDeclaration} scalarDeclaration - the scalar declaration
+     * @returns {string[]} attribute lines, empty if no validator
+     * @private
+     */
+    buildScalarValidatorLines(scalarDeclaration) {
+        const validator = scalarDeclaration.getValidator();
+        if (!validator) {return [];}
+        const lines = [];
+        const type = scalarDeclaration.getType();
+        if (type === 'String') {
+            if (validator.getMinLength()) {
+                lines.push(`[System.ComponentModel.DataAnnotations.MinLength(${validator.getMinLength()})]`);
+            }
+            if (validator.getMaxLength()) {
+                lines.push(`[System.ComponentModel.DataAnnotations.MaxLength(${validator.getMaxLength()})]`);
+            }
+            if (validator.getRegex()) {
+                lines.push(`[System.ComponentModel.DataAnnotations.RegularExpression(@"${validator.getRegex().source}", ErrorMessage = "Invalid characters")]`);
+            }
+        } else if (['Integer', 'Long', 'Double'].includes(type)) {
+            const lower = validator.getLowerBound();
+            const upper = validator.getUpperBound();
+            if (lower != null || upper != null) {
+                const csTypeMap = { Integer: 'int', Long: 'long', Double: 'double' };
+                const defaultMin = { Integer: '-2147483648', Long: '-9223372036854775808', Double: '-1.7976931348623157E+308' };
+                const defaultMax = { Integer: '2147483647', Long: '9223372036854775807', Double: '1.7976931348623157E+308' };
+                const csType = csTypeMap[type];
+                const lo = lower != null ? String(lower) : defaultMin[type];
+                const hi = upper != null ? String(upper) : defaultMax[type];
+                lines.push(`[System.ComponentModel.DataAnnotations.Range(typeof(${csType}), "${lo}", "${hi}")]`);
+            }
+        }
+        return lines;
     }
 
     /**
@@ -349,7 +393,9 @@ class CSharpVisitor {
         // For concerto.scalar.UUID, the alias resolves to System.Guid; use 'UUID' (the alias name).
         // For all other scalars, use the scalar's short name — it's a global using alias.
         const scalarTypeName = field.getType();
-        return this.writeField(field.getScalarField(), parameters, scalarTypeName, field.isOptional());
+        // Field-level default takes precedence over the scalar declaration's default.
+        const defaultValue = field.getDefaultValue() ?? field.getScalarField().getDefaultValue();
+        return this.writeField(field.getScalarField(), parameters, scalarTypeName, field.isOptional(), defaultValue);
     }
 
     /**
@@ -369,10 +415,11 @@ class CSharpVisitor {
      * @param {Object} parameters  - the parameter
      * @param {string} [externalFieldType] - the external field type like UUID (optional)
      * @param {bool} [isOptional] - the bool value indicating if external field type like UUID is optional (optional)
+     * @param {*} [scalarDefaultValue] - pre-resolved default value for scalar-typed fields (optional)
      * @return {Object} the result of visiting or null
      * @private
      */
-    writeField(field, parameters, externalFieldType, isOptional = false) {
+    writeField(field, parameters, externalFieldType, isOptional = false, scalarDefaultValue = undefined) {
         // write Map field
         if (ModelUtil.isMap?.(field)) {
             const mapDeclaration = field.getModelFile().getType(field.getType());
@@ -423,13 +470,13 @@ class CSharpVisitor {
             if (validator) {
                 const lower = validator.getLowerBound();
                 const upper = validator.getUpperBound();
-                if (lower !== null || upper !== null) {
+                if (lower != null || upper != null) {
                     const csTypeMap = { Integer: 'int', Long: 'long', Double: 'double' };
                     const defaultMin = { Integer: '-2147483648', Long: '-9223372036854775808', Double: '-1.7976931348623157E+308' };
                     const defaultMax = { Integer: '2147483647', Long: '9223372036854775807', Double: '1.7976931348623157E+308' };
                     const csType = csTypeMap[rawFieldType];
-                    const lo = lower !== null ? String(lower) : defaultMin[rawFieldType];
-                    const hi = upper !== null ? String(upper) : defaultMax[rawFieldType];
+                    const lo = lower != null ? String(lower) : defaultMin[rawFieldType];
+                    const hi = upper != null ? String(upper) : defaultMax[rawFieldType];
                     parameters.fileWriter.writeLine(1, `[System.ComponentModel.DataAnnotations.Range(typeof(${csType}), "${lo}", "${hi}")]`);
                 }
             }
@@ -447,6 +494,10 @@ class CSharpVisitor {
             nullableType = '?';
         }
 
+        const rawDefault = externalFieldType !== undefined ? scalarDefaultValue : field.getDefaultValue();
+        const csDefault = this.formatDefaultLiteral(rawDefault, rawFieldType, !!externalFieldType);
+        const getset = csDefault != null ? `{ get; set; } = ${csDefault};` : '{ get; set; }';
+
         const lines = this.toCSharpProperty(
             'public',
             field.getParent()?.getName(),
@@ -454,7 +505,7 @@ class CSharpVisitor {
             fieldType,
             array,
             nullableType,
-            '{ get; set; }',
+            getset,
             parameters
         );
         lines.forEach(line => parameters.fileWriter.writeLine(1, line));
@@ -532,6 +583,21 @@ class CSharpVisitor {
         );
         lines.forEach(line => parameters.fileWriter.writeLine(1, line));
         return null;
+    }
+
+    /**
+     * Format a Concerto default value as a C# literal suitable for a property initializer.
+     * String values are quoted; scalar-typed fields wrap the literal in `new(...)`.
+     * @param {*} value - the raw default value from getDefaultValue()
+     * @param {string} concertoType - the underlying Concerto primitive type
+     * @param {boolean} isScalar - true when the property type is a scalar struct
+     * @returns {string|null} C# literal string, or null if no default
+     * @private
+     */
+    formatDefaultLiteral(value, concertoType, isScalar) {
+        if (value == null) {return null;}
+        const rawLiteral = concertoType === 'String' ? `"${value}"` : String(value);
+        return isScalar ? `new(${rawLiteral})` : rawLiteral;
     }
 
     /**

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -281,7 +281,9 @@ class CSharpVisitor {
             : this.toCSharpType(scalarDeclaration.getType());
 
         const validatorLines = this.buildScalarValidatorLines(scalarDeclaration);
+        const converterName = `${identifier}JsonConverter`;
 
+        parameters.fileWriter.writeLine(0, `[System.Text.Json.Serialization.JsonConverter(typeof(${converterName}))]`);
         parameters.fileWriter.writeLine(0, `public readonly record struct ${identifier}(${csharpType} Value)`);
         parameters.fileWriter.writeLine(0, '{');
         if (validatorLines.length > 0) {
@@ -292,6 +294,41 @@ class CSharpVisitor {
         parameters.fileWriter.writeLine(1, `public static implicit operator ${identifier}(${csharpType} v) => new(v);`);
         parameters.fileWriter.writeLine(1, 'public override string ToString() => Value.ToString();');
         parameters.fileWriter.writeLine(0, '}');
+
+        // Companion JsonConverter so System.Text.Json reads/writes the struct as a bare scalar value
+        parameters.fileWriter.writeLine(0, `public class ${converterName} : System.Text.Json.Serialization.JsonConverter<${identifier}>`);
+        parameters.fileWriter.writeLine(0, '{');
+        if (csharpType === 'System.Guid') {
+            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> new(r.GetGuid());');
+            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value.ToString());');
+        } else if (csharpType === 'string') {
+            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> new(r.GetString()!);');
+            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value);');
+        } else if (csharpType === 'bool') {
+            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> new(r.GetBoolean());');
+            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> w.WriteBooleanValue(v.Value);');
+        } else if (['int', 'long', 'double'].includes(csharpType)) {
+            const getMethod = { int: 'GetInt32', long: 'GetInt64', double: 'GetDouble' }[csharpType];
+            const writeMethod = { int: 'WriteNumberValue', long: 'WriteNumberValue', double: 'WriteNumberValue' }[csharpType];
+            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, `=> new(r.${getMethod}());`);
+            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, `=> w.${writeMethod}(v.Value);`);
+        } else {
+            // fallback: serialize as string via ToString
+            parameters.fileWriter.writeLine(1, `public override ${identifier} Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, `=> new((${csharpType})System.Convert.ChangeType(r.GetString()!, typeof(${csharpType})));`);
+            parameters.fileWriter.writeLine(1, `public override void Write(System.Text.Json.Utf8JsonWriter w, ${identifier} v, System.Text.Json.JsonSerializerOptions o)`);
+            parameters.fileWriter.writeLine(2, '=> w.WriteStringValue(v.Value.ToString()!);');
+        }
+        parameters.fileWriter.writeLine(0, '}');
+
         return null;
     }
 
@@ -411,7 +448,12 @@ class CSharpVisitor {
         // For all other scalars, use the scalar's short name — it's a global using alias.
         const scalarTypeName = field.getType();
         // Field-level default takes precedence over the scalar declaration's default.
-        const defaultValue = field.getDefaultValue() ?? field.getScalarField().getDefaultValue();
+        const rawDefault = field.getDefaultValue() ?? field.getScalarField().getDefaultValue();
+        // UUID scalars wrap System.Guid — the struct constructor requires a Guid, not a string.
+        // Wrap the default in a pre-computed C# literal so formatDefaultLiteral emits the right code.
+        const defaultValue = (fqn === 'concerto.scalar.UUID' && rawDefault != null)
+            ? { __csharpLiteral: `new(System.Guid.Parse("${rawDefault}"))` }
+            : rawDefault;
         return this.writeField(field.getScalarField(), parameters, scalarTypeName, field.isOptional(), defaultValue);
     }
 
@@ -465,6 +507,7 @@ class CSharpVisitor {
         let isIdentifier = field.getName() === field.getParent()?.getIdentifierFieldName();
         if (isIdentifier) {
             parameters.fileWriter.writeLine(1, '[AccordProject.Concerto.Identifier()]');
+            parameters.fileWriter.writeLine(1, '[System.ComponentModel.DataAnnotations.Key]');
         }
 
         let fieldType = externalFieldType ? externalFieldType : this.getFieldType(field);
@@ -617,6 +660,8 @@ class CSharpVisitor {
      */
     formatDefaultLiteral(value, concertoType, isScalar) {
         if (value == null) {return null;}
+        // Pre-computed C# literal (e.g. UUID default needs System.Guid.Parse, not a bare string)
+        if (value?.__csharpLiteral) {return value.__csharpLiteral;}
         const rawLiteral = concertoType === 'String' ? `"${value}"` : String(value);
         return isScalar ? `new(${rawLiteral})` : rawLiteral;
     }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -695,6 +695,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 {
   "key": "org.acme.hr.base@1.0.0.cs",
   "value": "namespace org.acme.hr.base;
+using System.Collections.Generic;
 using AccordProject.Concerto;
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr.base", Version = "1.0.0", Name = "Category")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
@@ -776,6 +777,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 {
   "key": "org.acme.hr@1.0.0.cs",
   "value": "namespace org.acme.hr;
+using System.Collections.Generic;
 using org.acme.hr.base;
 using concerto.decorator;
 using AccordProject.Concerto;
@@ -815,12 +817,9 @@ public class Company : Concept {
    public string name { get; set; }
    public org.acme.hr.base.Address headquarters { get; set; }
    public Dictionary<string, string>? companyProperties { get; set; }
-   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<SSN, Employee>? employeeDirectory { get; set; }
-   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<SSN, TShirtSizeType>? employeeTShirtSizes { get; set; }
    public Dictionary<string, Concept>? employeeProfiles { get; set; }
-   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<string, SSN>? employeeSocialSecurityNumbers { get; set; }
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -797,9 +797,12 @@ public class Company : Concept {
    public string name { get; set; }
    public org.acme.hr.base.Address headquarters { get; set; }
    public Dictionary<string, string>? companyProperties { get; set; }
+   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<SSN, Employee>? employeeDirectory { get; set; }
+   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<SSN, TShirtSizeType>? employeeTShirtSizes { get; set; }
    public Dictionary<string, Concept>? employeeProfiles { get; set; }
+   [System.ComponentModel.DataAnnotations.ValidateComplexType]
    public Dictionary<string, SSN>? employeeSocialSecurityNumbers { get; set; }
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -853,6 +853,7 @@ public class Employee : Person {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.Employee";
    public string employeeId { get; set; }
+   [System.ComponentModel.DataAnnotations.Range(typeof(long), "1", "10")]
    public long salary { get; set; }
    public int numDependents { get; set; }
    public bool retired { get; set; }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -657,6 +657,7 @@ public abstract class Asset : Concept {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "concerto@1.0.0.Asset";
    [AccordProject.Concerto.Identifier()]
+   [System.ComponentModel.DataAnnotations.Key]
    [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
    public string _identifier { get; set; }
 }
@@ -666,6 +667,7 @@ public abstract class Participant : Concept {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "concerto@1.0.0.Participant";
    [AccordProject.Concerto.Identifier()]
+   [System.ComponentModel.DataAnnotations.Key]
    [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
    public string _identifier { get; set; }
 }
@@ -736,12 +738,21 @@ public class Address : Concept {
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum Level {
 }
+[System.Text.Json.Serialization.JsonConverter(typeof(TimeJsonConverter))]
 public readonly record struct Time(System.DateTime Value)
 {
    public static implicit operator System.DateTime(Time s) => s.Value;
    public static implicit operator Time(System.DateTime v) => new(v);
    public override string ToString() => Value.ToString();
 }
+public class TimeJsonConverter : System.Text.Json.Serialization.JsonConverter<Time>
+{
+   public override Time Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)
+      => new((System.DateTime)System.Convert.ChangeType(r.GetString()!, typeof(System.DateTime)));
+   public override void Write(System.Text.Json.Utf8JsonWriter w, Time v, System.Text.Json.JsonSerializerOptions o)
+      => w.WriteStringValue(v.Value.ToString()!);
+}
+[System.Text.Json.Serialization.JsonConverter(typeof(SSNJsonConverter))]
 public readonly record struct SSN(string Value)
 {
    [System.ComponentModel.DataAnnotations.RegularExpression(@"(\\d{3}-\\d{2}-\\d{4})+", ErrorMessage = "Invalid characters")]
@@ -749,6 +760,13 @@ public readonly record struct SSN(string Value)
    public static implicit operator string(SSN s) => s.Value;
    public static implicit operator SSN(string v) => new(v);
    public override string ToString() => Value.ToString();
+}
+public class SSNJsonConverter : System.Text.Json.Serialization.JsonConverter<SSN>
+{
+   public override SSN Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)
+      => new(r.GetString()!);
+   public override void Write(System.Text.Json.Utf8JsonWriter w, SSN v, System.Text.Json.JsonSerializerOptions o)
+      => w.WriteStringValue(v.Value);
 }
 ",
 }
@@ -820,6 +838,7 @@ public abstract class Equipment : Asset {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.Equipment";
    [AccordProject.Concerto.Identifier()]
+   [System.ComponentModel.DataAnnotations.Key]
    public string serialNumber { get; set; }
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
@@ -840,6 +859,7 @@ public abstract class Person : Participant {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.Person";
    [AccordProject.Concerto.Identifier()]
+   [System.ComponentModel.DataAnnotations.Key]
    [System.ComponentModel.DataAnnotations.MaxLength(254)]
    public string email { get; set; }
    public string firstName { get; set; }
@@ -903,17 +923,33 @@ public class ChangeOfAddress : Transaction {
    public Person Person { get; set; }
    public org.acme.hr.base.Address newAddress { get; set; }
 }
+[System.Text.Json.Serialization.JsonConverter(typeof(KinNameJsonConverter))]
 public readonly record struct KinName(string Value)
 {
    public static implicit operator string(KinName s) => s.Value;
    public static implicit operator KinName(string v) => new(v);
    public override string ToString() => Value.ToString();
 }
+public class KinNameJsonConverter : System.Text.Json.Serialization.JsonConverter<KinName>
+{
+   public override KinName Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)
+      => new(r.GetString()!);
+   public override void Write(System.Text.Json.Utf8JsonWriter w, KinName v, System.Text.Json.JsonSerializerOptions o)
+      => w.WriteStringValue(v.Value);
+}
+[System.Text.Json.Serialization.JsonConverter(typeof(KinTelephoneJsonConverter))]
 public readonly record struct KinTelephone(string Value)
 {
    public static implicit operator string(KinTelephone s) => s.Value;
    public static implicit operator KinTelephone(string v) => new(v);
    public override string ToString() => Value.ToString();
+}
+public class KinTelephoneJsonConverter : System.Text.Json.Serialization.JsonConverter<KinTelephone>
+{
+   public override KinTelephone Read(ref System.Text.Json.Utf8JsonReader r, System.Type t, System.Text.Json.JsonSerializerOptions o)
+      => new(r.GetString()!);
+   public override void Write(System.Text.Json.Utf8JsonWriter w, KinTelephone v, System.Text.Json.JsonSerializerOptions o)
+      => w.WriteStringValue(v.Value);
 }
 ",
 }

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -744,6 +744,8 @@ public readonly record struct Time(System.DateTime Value)
 }
 public readonly record struct SSN(string Value)
 {
+   [System.ComponentModel.DataAnnotations.RegularExpression(@"(\\d{3}-\\d{2}-\\d{4})+", ErrorMessage = "Invalid characters")]
+   public string Value { get; init; } = Value;
    public static implicit operator string(SSN s) => s.Value;
    public static implicit operator SSN(string v) => new(v);
    public override string ToString() => Value.ToString();
@@ -842,7 +844,7 @@ public abstract class Person : Participant {
    public string? middleNames { get; set; }
    public org.acme.hr.base.Address homeAddress { get; set; }
    [System.ComponentModel.DataAnnotations.RegularExpression(@"(\\d{3}-\\d{2}-\\d{4})+", ErrorMessage = "Invalid characters")]
-   public SSN ssn { get; set; }
+   public SSN ssn { get; set; } = new("000-00-0000");
    public double height { get; set; }
    public System.DateTime dob { get; set; }
    public Dictionary<KinName, KinTelephone> nextOfKin { get; set; }

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -581,6 +581,62 @@ public class SampleModel : Concept {
             file1.should.match(/public ScalarStringWithSameMinMaxLength scalarStringWithSameMinMaxLength/);
         });
 
+        it('should emit [Range] attribute for Integer, Long, and Double fields with range validators', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            concept RangeModel {
+                o Integer intBothBounds range=[1,100]
+                o Long longBothBounds range=[0,9999999999]
+                o Double doubleBothBounds range=[0.5,99.9]
+                o Integer intLowerOnly range=[5,]
+                o Double doubleUpperOnly range=[,1.0]
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(int\), "1", "100"\)\]/);
+            file1.should.match(/public int intBothBounds \{ get; set; \}/);
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(long\), "0", "9999999999"\)\]/);
+            file1.should.match(/public long longBothBounds \{ get; set; \}/);
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(double\), "0\.5", "99\.9"\)\]/);
+            file1.should.match(/public double doubleBothBounds \{ get; set; \}/);
+            // lower-only: upper defaults to type max
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(int\), "5", "2147483647"\)\]/);
+            file1.should.match(/public int intLowerOnly \{ get; set; \}/);
+            // upper-only: lower defaults to type min
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(double\), "-1\.7976931348623157E\+308", "1"\)\]/);
+            file1.should.match(/public double doubleUpperOnly \{ get; set; \}/);
+        });
+
+        it('should emit [Range] attribute for scalar fields backed by numeric types with range validators', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            scalar Age extends Integer range=[0,150]
+            scalar Salary extends Long range=[1,]
+            scalar Ratio extends Double range=[0.0,1.0]
+
+            concept Person {
+                o Age age
+                o Salary salary
+                o Ratio ratio optional
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(int\), "0", "150"\)\]/);
+            file1.should.match(/public Age age \{ get; set; \}/);
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(long\), "1", "9223372036854775807"\)\]/);
+            file1.should.match(/public Salary salary \{ get; set; \}/);
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Range\(typeof\(double\), "0", "1"\)\]/);
+            file1.should.match(/public Ratio\? ratio \{ get; set; \}/);
+        });
+
         it('should use UUID alias for scalar type UUID with different namespace than concerto.scalar', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -459,6 +459,7 @@ describe('CSharpVisitor', function () {
             const file1 = files.get('org.acme@1.2.3.cs');
             file1.should.match(/class Thing/);
             file1.should.match(/AccordProject.Concerto.Identifier\(\)/);
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.Key\]/);
             file1.should.match(/public string ThingId/);
         });
 
@@ -490,6 +491,126 @@ describe('CSharpVisitor', function () {
 
             const file2 = files.get('concerto.scalar@1.0.0.cs');
             file2.should.match(/public readonly record struct UUID\(System\.Guid Value\)/);
+        });
+
+        it('should emit a JsonConverter for a String-backed scalar (SSN round-trip)', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar SSN extends String regex=/\\d{3}-\\d{2}-\\d{4}/
+
+            concept Person identified by ssn {
+                o SSN ssn
+                o String givenName
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            // struct has [JsonConverter] attribute pointing to the companion converter
+            file.should.match(/\[System\.Text\.Json\.Serialization\.JsonConverter\(typeof\(SSNJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct SSN\(string Value\)/);
+
+            // companion converter reads/writes as bare string
+            file.should.match(/public class SSNJsonConverter : System\.Text\.Json\.Serialization\.JsonConverter<SSN>/);
+            file.should.match(/r\.GetString\(\)/);
+            file.should.match(/w\.WriteStringValue\(v\.Value\)/);
+
+            // field on Person still typed as SSN (not string)
+            file.should.match(/public SSN ssn \{ get; set; \}/);
+        });
+
+        it('should emit a JsonConverter for a System.Guid-backed scalar (UUID round-trip)', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace concerto.scalar@1.0.0
+
+            scalar UUID extends String default="00000000-0000-0000-0000-000000000000"
+            `);
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            import concerto.scalar@1.0.0.{ UUID }
+
+            concept Thing {
+                o UUID id
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const scalarFile = fileWriter.getFilesInMemory().get('concerto.scalar@1.0.0.cs');
+
+            // struct is Guid-backed
+            scalarFile.should.match(/public readonly record struct UUID\(System\.Guid Value\)/);
+            // converter attribute
+            scalarFile.should.match(/\[System\.Text\.Json\.Serialization\.JsonConverter\(typeof\(UUIDJsonConverter\)\)\]/);
+            // converter reads as Guid, writes as string
+            scalarFile.should.match(/public class UUIDJsonConverter : System\.Text\.Json\.Serialization\.JsonConverter<UUID>/);
+            scalarFile.should.match(/r\.GetGuid\(\)/);
+            scalarFile.should.match(/w\.WriteStringValue\(v\.Value\.ToString\(\)\)/);
+        });
+
+        it('should emit a JsonConverter for an Integer-backed scalar (numeric round-trip)', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Age extends Integer range=[0,150]
+
+            concept Person {
+                o Age age
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[System\.Text\.Json\.Serialization\.JsonConverter\(typeof\(AgeJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Age\(int Value\)/);
+            file.should.match(/public class AgeJsonConverter : System\.Text\.Json\.Serialization\.JsonConverter<Age>/);
+            file.should.match(/r\.GetInt32\(\)/);
+            file.should.match(/w\.WriteNumberValue\(v\.Value\)/);
+        });
+
+        it('should emit a JsonConverter for a Double-backed scalar (numeric round-trip)', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Weight extends Double range=[0.0,500.0]
+
+            concept Item {
+                o Weight weight
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[System\.Text\.Json\.Serialization\.JsonConverter\(typeof\(WeightJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Weight\(double Value\)/);
+            file.should.match(/public class WeightJsonConverter : System\.Text\.Json\.Serialization\.JsonConverter<Weight>/);
+            file.should.match(/r\.GetDouble\(\)/);
+            file.should.match(/w\.WriteNumberValue\(v\.Value\)/);
+        });
+
+        it('should emit a JsonConverter for a Boolean-backed scalar (bool round-trip)', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Flag extends Boolean
+
+            concept Config {
+                o Flag enabled
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[System\.Text\.Json\.Serialization\.JsonConverter\(typeof\(FlagJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Flag\(bool Value\)/);
+            file.should.match(/public class FlagJsonConverter : System\.Text\.Json\.Serialization\.JsonConverter<Flag>/);
+            file.should.match(/r\.GetBoolean\(\)/);
+            file.should.match(/w\.WriteBooleanValue\(v\.Value\)/);
         });
 
         it('should use regex annotation when regex pattern provided to a field', () => {

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -805,30 +805,6 @@ public class SampleModel : Concept {
             file1.should.match(/public Score score \{ get; set; \} = new\(100\);/);
         });
 
-        it('should emit [ValidateComplexType] on a map field whose value type is a scalar with validators', () => {
-            sandbox.restore(); // allow ModelUtil.isMap to work normally
-            const modelManager = new ModelManager({ strict: true });
-            modelManager.addCTOModel(`
-            namespace org.acme@1.2.3
-
-            scalar SSN extends String regex=/\\d{3}-\\d{2}-\\d{4}/
-
-            map PhoneBook {
-                o String
-                o SSN
-            }
-
-            concept Person {
-                o PhoneBook phoneBook
-            }
-            `);
-            csharpVisitor.visit(modelManager, { fileWriter });
-            const files = fileWriter.getFilesInMemory();
-            const file1 = files.get('org.acme@1.2.3.cs');
-            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.ValidateComplexType\]/);
-            file1.should.match(/public Dictionary<string, SSN>.*phoneBook \{ get; set; \}/);
-        });
-
         it('should use UUID alias for scalar type UUID with different namespace than concerto.scalar', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -684,6 +684,30 @@ public class SampleModel : Concept {
             file1.should.match(/public Score score \{ get; set; \} = new\(100\);/);
         });
 
+        it('should emit [ValidateComplexType] on a map field whose value type is a scalar with validators', () => {
+            sandbox.restore(); // allow ModelUtil.isMap to work normally
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            scalar SSN extends String regex=/\\d{3}-\\d{2}-\\d{4}/
+
+            map PhoneBook {
+                o String
+                o SSN
+            }
+
+            concept Person {
+                o PhoneBook phoneBook
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/\[System\.ComponentModel\.DataAnnotations\.ValidateComplexType\]/);
+            file1.should.match(/public Dictionary<string, SSN>.*phoneBook \{ get; set; \}/);
+        });
+
         it('should use UUID alias for scalar type UUID with different namespace than concerto.scalar', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -613,6 +613,143 @@ describe('CSharpVisitor', function () {
             file.should.match(/w\.WriteBooleanValue\(v\.Value\)/);
         });
 
+        it('should emit a Newtonsoft JsonConverter for a String-backed scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar SSN extends String regex=/\\d{3}-\\d{2}-\\d{4}/
+
+            concept Person identified by ssn {
+                o SSN ssn
+                o String givenName
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(SSNJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct SSN\(string Value\)/);
+            file.should.match(/public class SSNJsonConverter : Newtonsoft\.Json\.JsonConverter<SSN>/);
+            file.should.match(/\(string\)r\.Value!/);
+            file.should.match(/w\.WriteValue\(v\.Value\)/);
+        });
+
+        it('should emit a Newtonsoft JsonConverter for a UUID scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace concerto.scalar@1.0.0
+
+            scalar UUID extends String default="00000000-0000-0000-0000-000000000000"
+            `);
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            import concerto.scalar@1.0.0.{ UUID }
+
+            concept Thing {
+                o UUID id
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const scalarFile = fileWriter.getFilesInMemory().get('concerto.scalar@1.0.0.cs');
+
+            // struct is Guid-backed
+            scalarFile.should.match(/public readonly record struct UUID\(System\.Guid Value\)/);
+            // converter attribute uses Newtonsoft
+            scalarFile.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(UUIDJsonConverter\)\)\]/);
+            // converter extends Newtonsoft base
+            scalarFile.should.match(/public class UUIDJsonConverter : Newtonsoft\.Json\.JsonConverter<UUID>/);
+            // Newtonsoft-style read/write
+            scalarFile.should.match(/public override UUID ReadJson\(/);
+            scalarFile.should.match(/public override void WriteJson\(/);
+            scalarFile.should.match(/System\.Guid\.Parse\(\(string\)r\.Value!\)/);
+        });
+
+        it('should emit a Newtonsoft JsonConverter for an Integer scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Age extends Integer range=[0,150]
+
+            concept Person {
+                o Age age
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(AgeJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Age\(int Value\)/);
+            file.should.match(/public class AgeJsonConverter : Newtonsoft\.Json\.JsonConverter<Age>/);
+            file.should.match(/System\.Convert\.ToInt32\(r\.Value\)/);
+            file.should.match(/w\.WriteValue\(v\.Value\)/);
+        });
+
+        it('should emit a Newtonsoft JsonConverter for a Long scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar BigNumber extends Long
+
+            concept Item {
+                o BigNumber count
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(BigNumberJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct BigNumber\(long Value\)/);
+            file.should.match(/public class BigNumberJsonConverter : Newtonsoft\.Json\.JsonConverter<BigNumber>/);
+            file.should.match(/System\.Convert\.ToInt64\(r\.Value\)/);
+            file.should.match(/w\.WriteValue\(v\.Value\)/);
+        });
+
+        it('should emit a Newtonsoft JsonConverter for a Double scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Weight extends Double range=[0.0,500.0]
+
+            concept Item {
+                o Weight weight
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(WeightJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Weight\(double Value\)/);
+            file.should.match(/public class WeightJsonConverter : Newtonsoft\.Json\.JsonConverter<Weight>/);
+            file.should.match(/System\.Convert\.ToDouble\(r\.Value\)/);
+            file.should.match(/w\.WriteValue\(v\.Value\)/);
+        });
+
+        it('should emit a Newtonsoft JsonConverter for a Boolean scalar with useNewtonsoftJson flag', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.0.0
+
+            scalar Flag extends Boolean
+
+            concept Config {
+                o Flag enabled
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, useNewtonsoftJson: true });
+            const file = fileWriter.getFilesInMemory().get('org.acme@1.0.0.cs');
+
+            file.should.match(/\[Newtonsoft\.Json\.JsonConverter\(typeof\(FlagJsonConverter\)\)\]/);
+            file.should.match(/public readonly record struct Flag\(bool Value\)/);
+            file.should.match(/public class FlagJsonConverter : Newtonsoft\.Json\.JsonConverter<Flag>/);
+            file.should.match(/\(bool\)r\.Value!/);
+            file.should.match(/w\.WriteValue\(v\.Value\)/);
+        });
+
         it('should use regex annotation when regex pattern provided to a field', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(fs.readFileSync(path.resolve(__dirname, '../data/model/agreement.cto'), 'utf8'), 'agreement.cto');

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -637,6 +637,53 @@ public class SampleModel : Concept {
             file1.should.match(/public Ratio\? ratio \{ get; set; \}/);
         });
 
+        it('should emit property initializers for default values on primitive fields', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            concept Defaults {
+                o String name default="Alice"
+                o Integer count default=0
+                o Long big default=9999999999
+                o Double rate default=3.14
+                o Boolean active default=true
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/public string name \{ get; set; \} = "Alice";/);
+            file1.should.match(/public int count \{ get; set; \} = 0;/);
+            file1.should.match(/public long big \{ get; set; \} = 9999999999;/);
+            file1.should.match(/public double rate \{ get; set; \} = 3\.14;/);
+            file1.should.match(/public bool active \{ get; set; \} = true;/);
+        });
+
+        it('should emit property initializers for default values on scalar fields', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            scalar SSN extends String default="000-00-0000"
+            scalar Score extends Integer default=100
+
+            concept Person {
+                o SSN ssn
+                o SSN customSsn default="123-45-6789"
+                o Score score
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            // uses scalar declaration default
+            file1.should.match(/public SSN ssn \{ get; set; \} = new\("000-00-0000"\);/);
+            // field-level default overrides scalar declaration default
+            file1.should.match(/public SSN customSsn \{ get; set; \} = new\("123-45-6789"\);/);
+            file1.should.match(/public Score score \{ get; set; \} = new\(100\);/);
+        });
+
         it('should use UUID alias for scalar type UUID with different namespace than concerto.scalar', () => {
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(`


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

## Summary

Significantly improves the C# code generator to produce idiomatic, type-safe C# from Concerto models.  This PR adds DataAnnotations validation attributes, and emits default property initializers.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Scalar struct validators
  When a scalar declares a validator (regex, length, range), the Value property is explicitly declared with the corresponding DataAnnotations attribute:
    ```
    public readonly record struct SSN(string Value)
    {
        [System.ComponentModel.DataAnnotations.RegularExpression(@"\d{3}-\d{2}-\d{4}", ErrorMessage = "Invalid characters")]
        public string Value { get; init; } = Value;
        ...
    }
    ```
- <TWO> Numeric range validators on fields
  `Integer`, `Long`, and `Double` fields with a range validator emit `[Range]`:
  ```
  [System.ComponentModel.DataAnnotations.Range(typeof(int), "1", "100")]
  public int salary { get; set; }
  ```
  Open bounds (only min or only max declared) fill to the type's natural min/max.

- <THREE> Default property initializers
  Fields with a default value emit a C# property initializer:
  ```
  public string name { get; set; } = "Alice";
  public SSN ssn { get; set; } = new("000-00-00-0000");
  ```
  For scalar-typed fields, the field-level default takes precedence over the scalar declaration's default.


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
