### PR TITLE
fix(csharp): emit required for non-optional arrays of scalar and enum types

### DIFF
--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -637,11 +637,12 @@ class CSharpVisitor {
         if (!parameters.useRequiredForNonOptionalReferenceTypes) {return false;}
         if (options.nullableType) {return false;}
         if (options.hasDefault) {return false;}
+        if (options.isArray) {return true;}
         // Scalar aliases are generated as record structs (value types), not reference types.
         if (options.isScalarAlias) {return false;}
         if (options.isEnum) {return false;}
         if (!options.csharpType) {return false;}
-        return this.isCSharpReferenceType(options.csharpType, !!options.isArray);
+        return this.isCSharpReferenceType(options.csharpType, false);
     }
 
     /**

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -922,8 +922,10 @@ public class SampleModel : Concept {
                 o Integer count
                 o String nick optional
                 o SSN ssn
+                o SSN[] ssns
                 o Status status default="ACTIVE"
                 o Status state
+                o Status[] states
                 o Child child
                 o Child[] children
             }
@@ -935,8 +937,10 @@ public class SampleModel : Concept {
             file1.should.match(/public int count \{ get; set; \}/);
             file1.should.match(/public string\? nick \{ get; set; \}/);
             file1.should.match(/public SSN ssn \{ get; set; \}/);
+            file1.should.match(/public required SSN\[\] ssns \{ get; set; \}/);
             file1.should.match(/public Status status \{ get; set; \} = Status.Active;/);
             file1.should.match(/public Status state \{ get; set; \}/);
+            file1.should.match(/public required Status\[\] states \{ get; set; \}/);
             file1.should.match(/public required Child child \{ get; set; \}/);
             file1.should.match(/public required Child\[\] children \{ get; set; \}/);
             file1.should.not.match(/public required SSN ssn \{ get; set; \}/);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
`shouldEmitRequired()` checked `isScalarAlias` and `isEnum` before `isArray`, causing it to return `false` for non-optional arrays of scalar types (e.g. `UUID[]`) and enum types (e.g. `Status[]`). In C#, arrays are always reference types; even `Guid[]` or `Status[]`, and should receive the required modifier when `useRequiredForNonOptionalReferenceTypes` is enabled.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
