### PR TITLE
fix(*): resolve typeScript visitor imports for map types

### DIFF
--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -142,8 +142,9 @@ class TypescriptVisitor {
                         if (!property.isPrimitive()) {
                             const typeNamespace = ModelUtil.getNamespace(property.getFullyQualifiedTypeName());
                             const typeName = ModelUtil.getShortName(property.getFullyQualifiedTypeName());
+                            const isMapRef = declaration.getModelFile().getModelManager().getType(property.getFullyQualifiedTypeName?.()).isMapDeclaration?.();
                             addImport(typeNamespace,
-                                property.isTypeEnum?.() || property.isTypeScalar?.() ? typeName : `I${typeName}`);
+                                property.isTypeEnum?.() || property.isTypeScalar?.() || isMapRef ? typeName : `I${typeName}`);
                         }
                     });
 

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6997,7 +6997,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 // Warning: Beware of circular dependencies when modifying these imports
 
 // Warning: Beware of circular dependencies when modifying these imports
-import {Time,SSN,IAddress,IEmployeeTShirtSizes} from './org.acme.hr.base@1.0.0';
+import {Time,SSN,IAddress,EmployeeTShirtSizes} from './org.acme.hr.base@1.0.0';
 import {IDecorator} from './concerto.decorator@1.0.0';
 import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
 

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -247,10 +247,14 @@ describe('TypescriptVisitor', function () {
             mockClassDeclaration.accept = acceptSpy;
 
             let mockClassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
-            mockClassDeclaration.isEnum.returns(false);
+            mockClassDeclaration2.isEnum.returns(false);
             mockClassDeclaration2.getSuperType.returns('super.Parent');
             mockClassDeclaration2.getProperties.returns([]);
             mockClassDeclaration2.accept = acceptSpy;
+
+            let mockModelManager = sinon.createStubInstance(ModelManager);
+            mockModelManager.isModelManager.returns(true);
+            mockModelManager.getType.returns({ isMapDeclaration: () => false });
 
             let mockModelFile = sinon.createStubInstance(ModelFile);
             mockModelFile.getNamespace.returns('org.acme');
@@ -266,6 +270,9 @@ describe('TypescriptVisitor', function () {
                 'super.Property3',
                 'super.Parent'
             ]);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockClassDeclaration2.getModelFile.returns(mockModelFile);
             mockModelFile.imports= [];
 
             typescriptVisitor.visitModelFile(mockModelFile, param);
@@ -323,6 +330,7 @@ describe('TypescriptVisitor', function () {
 
             let mockModelManager = sinon.createStubInstance(ModelManager);
             mockModelManager.isModelManager.returns(true);
+            mockModelManager.getType.returns({ isMapDeclaration: () => false });
 
             let mockModelFile = sinon.createStubInstance(ModelFile);
             mockModelFile.isModelFile.returns(true);
@@ -337,6 +345,7 @@ describe('TypescriptVisitor', function () {
                 'org.org2.Import1'
             ]);
             mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
             mockModelFile.imports= [];
             typescriptVisitor.visitModelFile(mockModelFile, param);
 
@@ -438,8 +447,14 @@ describe('TypescriptVisitor', function () {
 
             mockClassDeclaration.getDirectSubclasses.returns([]);
 
+            let mockModelManager = sinon.createStubInstance(ModelManager);
+            mockModelManager.isModelManager.returns(true);
+            mockModelManager.getType.returns({ isMapDeclaration: () => false });
+
             let mockModelFile = sinon.createStubInstance(ModelFile);
             mockModelFile.getNamespace.returns('org.test.collection');
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
             mockModelFile.imports = [
                 {
                     '$class': 'concerto.metamodel@1.0.0.ImportTypes',


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>

Fixed TypeScript visitor code generation to correctly import map alias types without interface prefixes, ensuring generated imports match the emitted type names.

Map declarations emit `export type Name = Map<key, value>`. For map types from external namespaces, the imports must use direct type names (e.g., `import {MapTypeName}` not `import {IMapTypeName}`). This fix ensures consistency between what's imported and what's used in the generated types.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Property import logic now correctly identifies when to use direct type names vs. interface-prefixed names


### Related Issues
- Issue #<[237](https://github.com/accordproject/concerto-codegen/issues/237)>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
