### PR TITLE
fix(codegen): update Level enum to include NONE value and adjust JSON…

### DIFF
--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -444,8 +444,9 @@ class JSONSchemaVisitor {
             let mapKey   = mapDeclaration.getModelFile().getType(mapDeclaration.getKey().getType());
             let mapValue = mapDeclaration.getModelFile().getType(mapDeclaration.getValue().getType());
 
+            // Do not set $id on inlined map schemas: inherited fields (e.g. Person.nextOfKin
+            // on Employee, Contractor, Manager) would share the same $id and break Ajv.
             const jsonSchema = {
-                $id: field.getFullyQualifiedName(),
                 schema: {
                     title: mapDeclaration.getName(),
                     description : `An instance of ${field.getFullyQualifiedTypeName()}`,

--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -532,13 +532,18 @@ class JSONSchemaVisitor {
             schema: {
                 title: enumDeclaration.getName(),
                 description : `An instance of ${enumDeclaration.getFullyQualifiedName()}`,
-                enum: []
             }};
 
-        // Walk over all of the properties which should just be enum value declarations.
-        enumDeclaration.getProperties().forEach((property) => {
-            result.schema.enum.push(property.accept(this, parameters));
-        });
+        const enumValues = enumDeclaration.getProperties().map((property) =>
+            property.accept(this, parameters)
+        );
+
+        if (enumValues.length === 0) {
+            // Empty Concerto enums are valid, but JSON Schema requires enum to have >= 1 item.
+            result.schema.not = {};
+        } else {
+            result.schema.enum = enumValues;
+        }
 
         // add the decorators
         const decorators = this.getDecorators(enumDeclaration);

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -44,10 +44,8 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 }
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
-class \`org.acme.hr.base@1.0.0.Level\` {
-<< enumeration>>
-   + NONE
-}
+class \`org.acme.hr.base@1.0.0.Level\`
+<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
 
 class \`org.acme.hr@1.0.0.pii\` {
 << concept>>
@@ -250,7 +248,6 @@ class org.acme.hr.base_1_0_0.Address {
 }
 org.acme.hr.base_1_0_0.Address "1" *-- "1" org.acme.hr.base_1_0_0.State : state
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
-   + NONE
 }
 class org.acme.hr_1_0_0.pii {
    + Boolean isPii
@@ -459,7 +456,6 @@ protocol MyProtocol {
    }
 
    enum Level {
-      NONE
    }
 
 }
@@ -739,7 +735,6 @@ public class Address : Concept {
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum Level {
-      NONE,
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(TimeJsonConverter))]
 public readonly record struct Time(System.DateTime Value)
@@ -1036,7 +1031,6 @@ type Address struct {
 }
 type Level int
 const (
-   NONE Level = 1 + iota
 )
 ",
 }
@@ -1184,7 +1178,7 @@ type Address {
    country: String!
 }
 enum Level {
-   NONE
+   _: Boolean
 }
 # namespace org.acme.hr@1.0.0
 type pii @example @usedBy {
@@ -1661,7 +1655,6 @@ package org.acme.hr.base;
 import com.fasterxml.jackson.annotation.*;
 @JsonIgnoreProperties({"$class"})
 public enum Level {
-   NONE,
 }
 ",
 }
@@ -2436,9 +2429,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
     "org.acme.hr.base@1.0.0.Level": {
       "title": "Level",
       "description": "An instance of org.acme.hr.base@1.0.0.Level",
-      "enum": [
-        "NONE"
-      ]
+      "not": {}
     },
     "org.acme.hr.base@1.0.0.Time": {
       "format": "date-time",
@@ -3242,9 +3233,7 @@ No fields.
 
 ### Level (Enumeration)
 
-| Value | Description | 
-| ------ | ------------------- |
-| NONE | |
+No values.
 
 
 ## Diagram
@@ -3290,10 +3279,8 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 }
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
-class \`org.acme.hr.base@1.0.0.Level\` {
-<< enumeration>>
-   + NONE
-}
+class \`org.acme.hr.base@1.0.0.Level\`
+<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
 
 \`\`\`
 
@@ -3740,10 +3727,8 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
 \`org.acme.hr.base@1.0.0.Address\` --|> \`concerto@1.0.0.Concept\`
-class \`org.acme.hr.base@1.0.0.Level\` {
-<< enumeration>>
-   + NONE
-}
+class \`org.acme.hr.base@1.0.0.Level\`
+<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
 
 \`org.acme.hr.base@1.0.0.Level\` --|> \`concerto@1.0.0.Concept\`
 class \`org.acme.hr@1.0.0.pii\` {
@@ -4043,8 +4028,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
          </Property>
       </ComplexType>
       <EnumType Name="Level">
-         <Member Name="NONE">
-         </Member>
       </EnumType>
    <EntityContainer Name="org.acme.hr.baseService">
    </EntityContainer>
@@ -4352,9 +4335,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       "org.acme.hr.base@1.0.0.Level": {
         "title": "Level",
         "description": "An instance of org.acme.hr.base@1.0.0.Level",
-        "enum": [
-          "NONE"
-        ]
+        "not": {}
       },
       "org.acme.hr.base@1.0.0.Time": {
         "format": "date-time",
@@ -5373,7 +5354,6 @@ class org.acme.hr.base_1_0_0.Address {
 org.acme.hr.base_1_0_0.Address "1" *-- "1" org.acme.hr.base_1_0_0.State : state
 org.acme.hr.base_1_0_0.Address --|> concerto_1_0_0.Concept
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
-   + NONE
 }
 org.acme.hr.base_1_0_0.Level --|> concerto_1_0_0.Concept
 class org.acme.hr_1_0_0.pii {
@@ -5531,9 +5511,7 @@ message Address {
   string zipCode = 5;
 }
 
-enum Level {
-  Level_NONE = 0;
-}
+enum Level {}
 
 ",
 }
@@ -6157,8 +6135,6 @@ pub struct Address {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Level {
-   #[allow(non_camel_case_types)]
-   NONE,
 }
 
 ",
@@ -6895,7 +6871,6 @@ export interface IAddress extends IConcept {
 }
 
 export enum Level {
-   NONE = 'NONE',
 }
 
 export type Time = Date;
@@ -7074,8 +7049,6 @@ declarations:
       - zipCode: Zip Code of the Address
       - country: Country of the Address
   - Level: Level
-    properties:
-      - NONE: NONE of the Level
   - Time: Time
   - SSN: SSN
 ",
@@ -7353,7 +7326,6 @@ xmlns:concerto="concerto"
 <xs:element name="Address" type="org.acme.hr.base:Address"/>
 <xs:simpleType name="Level">
    <xs:restriction base="xs:string">
-      <xs:enumeration value="NONE"/>
    </xs:restriction>
 </xs:simpleType>
 <xs:element name="Level" type="org.acme.hr.base:Level"/>

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -44,8 +44,10 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 }
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
-class \`org.acme.hr.base@1.0.0.Level\`
-<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
+class \`org.acme.hr.base@1.0.0.Level\` {
+<< enumeration>>
+   + NONE
+}
 
 class \`org.acme.hr@1.0.0.pii\` {
 << concept>>
@@ -248,6 +250,7 @@ class org.acme.hr.base_1_0_0.Address {
 }
 org.acme.hr.base_1_0_0.Address "1" *-- "1" org.acme.hr.base_1_0_0.State : state
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
+   + NONE
 }
 class org.acme.hr_1_0_0.pii {
    + Boolean isPii
@@ -456,6 +459,7 @@ protocol MyProtocol {
    }
 
    enum Level {
+      NONE
    }
 
 }
@@ -735,6 +739,7 @@ public class Address : Concept {
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 public enum Level {
+      NONE,
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(TimeJsonConverter))]
 public readonly record struct Time(System.DateTime Value)
@@ -1031,6 +1036,7 @@ type Address struct {
 }
 type Level int
 const (
+   NONE Level = 1 + iota
 )
 ",
 }
@@ -1178,7 +1184,7 @@ type Address {
    country: String!
 }
 enum Level {
-   _: Boolean
+   NONE
 }
 # namespace org.acme.hr@1.0.0
 type pii @example @usedBy {
@@ -1655,6 +1661,7 @@ package org.acme.hr.base;
 import com.fasterxml.jackson.annotation.*;
 @JsonIgnoreProperties({"$class"})
 public enum Level {
+   NONE,
 }
 ",
 }
@@ -2429,7 +2436,9 @@ exports[`codegen #formats check we can convert all formats from namespace versio
     "org.acme.hr.base@1.0.0.Level": {
       "title": "Level",
       "description": "An instance of org.acme.hr.base@1.0.0.Level",
-      "enum": []
+      "enum": [
+        "NONE"
+      ]
     },
     "org.acme.hr.base@1.0.0.Time": {
       "format": "date-time",
@@ -2532,7 +2541,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "$ref": "#/definitions/org.acme.hr.base@1.0.0.Address"
         },
         "companyProperties": {
-          "$id": "org.acme.hr@1.0.0.Company.companyProperties",
           "schema": {
             "title": "CompanyProperties",
             "description": "An instance of org.acme.hr@1.0.0.CompanyProperties",
@@ -2546,7 +2554,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           }
         },
         "employeeDirectory": {
-          "$id": "org.acme.hr@1.0.0.Company.employeeDirectory",
           "schema": {
             "title": "EmployeeDirectory",
             "description": "An instance of org.acme.hr@1.0.0.EmployeeDirectory",
@@ -2561,7 +2568,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           }
         },
         "employeeTShirtSizes": {
-          "$id": "org.acme.hr@1.0.0.Company.employeeTShirtSizes",
           "schema": {
             "title": "EmployeeTShirtSizes",
             "description": "An instance of org.acme.hr.base@1.0.0.EmployeeTShirtSizes",
@@ -2576,7 +2582,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           }
         },
         "employeeProfiles": {
-          "$id": "org.acme.hr@1.0.0.Company.employeeProfiles",
           "schema": {
             "title": "EmployeeProfiles",
             "description": "An instance of org.acme.hr@1.0.0.EmployeeProfiles",
@@ -2590,7 +2595,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           }
         },
         "employeeSocialSecurityNumbers": {
-          "$id": "org.acme.hr@1.0.0.Company.employeeSocialSecurityNumbers",
           "schema": {
             "title": "EmployeeSocialSecurityNumbers",
             "description": "An instance of org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers",
@@ -2743,7 +2747,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "type": "string"
         },
         "nextOfKin": {
-          "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
           "schema": {
             "title": "NextOfKin",
             "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -2850,7 +2853,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "type": "string"
         },
         "nextOfKin": {
-          "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
           "schema": {
             "title": "NextOfKin",
             "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -2949,7 +2951,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "type": "string"
         },
         "nextOfKin": {
-          "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
           "schema": {
             "title": "NextOfKin",
             "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -3061,7 +3062,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "type": "string"
         },
         "nextOfKin": {
-          "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
           "schema": {
             "title": "NextOfKin",
             "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -3242,7 +3242,9 @@ No fields.
 
 ### Level (Enumeration)
 
-No values.
+| Value | Description | 
+| ------ | ------------------- |
+| NONE | |
 
 
 ## Diagram
@@ -3288,8 +3290,10 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 }
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
-class \`org.acme.hr.base@1.0.0.Level\`
-<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
+class \`org.acme.hr.base@1.0.0.Level\` {
+<< enumeration>>
+   + NONE
+}
 
 \`\`\`
 
@@ -3736,8 +3740,10 @@ class \`org.acme.hr.base@1.0.0.Address\` {
 
 \`org.acme.hr.base@1.0.0.Address\` "1" *-- "1" \`org.acme.hr.base@1.0.0.State\`
 \`org.acme.hr.base@1.0.0.Address\` --|> \`concerto@1.0.0.Concept\`
-class \`org.acme.hr.base@1.0.0.Level\`
-<< enumeration>> \`org.acme.hr.base@1.0.0.Level\`
+class \`org.acme.hr.base@1.0.0.Level\` {
+<< enumeration>>
+   + NONE
+}
 
 \`org.acme.hr.base@1.0.0.Level\` --|> \`concerto@1.0.0.Concept\`
 class \`org.acme.hr@1.0.0.pii\` {
@@ -4037,6 +4043,8 @@ exports[`codegen #formats check we can convert all formats from namespace versio
          </Property>
       </ComplexType>
       <EnumType Name="Level">
+         <Member Name="NONE">
+         </Member>
       </EnumType>
    <EntityContainer Name="org.acme.hr.baseService">
    </EntityContainer>
@@ -4344,7 +4352,9 @@ exports[`codegen #formats check we can convert all formats from namespace versio
       "org.acme.hr.base@1.0.0.Level": {
         "title": "Level",
         "description": "An instance of org.acme.hr.base@1.0.0.Level",
-        "enum": []
+        "enum": [
+          "NONE"
+        ]
       },
       "org.acme.hr.base@1.0.0.Time": {
         "format": "date-time",
@@ -4447,7 +4457,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             "$ref": "#/components/schemas/org.acme.hr.base@1.0.0.Address"
           },
           "companyProperties": {
-            "$id": "org.acme.hr@1.0.0.Company.companyProperties",
             "schema": {
               "title": "CompanyProperties",
               "description": "An instance of org.acme.hr@1.0.0.CompanyProperties",
@@ -4461,7 +4470,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             }
           },
           "employeeDirectory": {
-            "$id": "org.acme.hr@1.0.0.Company.employeeDirectory",
             "schema": {
               "title": "EmployeeDirectory",
               "description": "An instance of org.acme.hr@1.0.0.EmployeeDirectory",
@@ -4476,7 +4484,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             }
           },
           "employeeTShirtSizes": {
-            "$id": "org.acme.hr@1.0.0.Company.employeeTShirtSizes",
             "schema": {
               "title": "EmployeeTShirtSizes",
               "description": "An instance of org.acme.hr.base@1.0.0.EmployeeTShirtSizes",
@@ -4491,7 +4498,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             }
           },
           "employeeProfiles": {
-            "$id": "org.acme.hr@1.0.0.Company.employeeProfiles",
             "schema": {
               "title": "EmployeeProfiles",
               "description": "An instance of org.acme.hr@1.0.0.EmployeeProfiles",
@@ -4505,7 +4511,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             }
           },
           "employeeSocialSecurityNumbers": {
-            "$id": "org.acme.hr@1.0.0.Company.employeeSocialSecurityNumbers",
             "schema": {
               "title": "EmployeeSocialSecurityNumbers",
               "description": "An instance of org.acme.hr@1.0.0.EmployeeSocialSecurityNumbers",
@@ -4658,7 +4663,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             "type": "string"
           },
           "nextOfKin": {
-            "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
             "schema": {
               "title": "NextOfKin",
               "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -4765,7 +4769,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             "type": "string"
           },
           "nextOfKin": {
-            "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
             "schema": {
               "title": "NextOfKin",
               "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -4864,7 +4867,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             "type": "string"
           },
           "nextOfKin": {
-            "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
             "schema": {
               "title": "NextOfKin",
               "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -4976,7 +4978,6 @@ exports[`codegen #formats check we can convert all formats from namespace versio
             "type": "string"
           },
           "nextOfKin": {
-            "$id": "org.acme.hr@1.0.0.Person.nextOfKin",
             "schema": {
               "title": "NextOfKin",
               "description": "An instance of org.acme.hr@1.0.0.NextOfKin",
@@ -5372,6 +5373,7 @@ class org.acme.hr.base_1_0_0.Address {
 org.acme.hr.base_1_0_0.Address "1" *-- "1" org.acme.hr.base_1_0_0.State : state
 org.acme.hr.base_1_0_0.Address --|> concerto_1_0_0.Concept
 class org.acme.hr.base_1_0_0.Level << (E,grey) >> {
+   + NONE
 }
 org.acme.hr.base_1_0_0.Level --|> concerto_1_0_0.Concept
 class org.acme.hr_1_0_0.pii {
@@ -5529,7 +5531,9 @@ message Address {
   string zipCode = 5;
 }
 
-enum Level {}
+enum Level {
+  Level_NONE = 0;
+}
 
 ",
 }
@@ -6153,6 +6157,8 @@ pub struct Address {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Level {
+   #[allow(non_camel_case_types)]
+   NONE,
 }
 
 ",
@@ -6889,6 +6895,7 @@ export interface IAddress extends IConcept {
 }
 
 export enum Level {
+   NONE = 'NONE',
 }
 
 export type Time = Date;
@@ -7067,6 +7074,8 @@ declarations:
       - zipCode: Zip Code of the Address
       - country: Country of the Address
   - Level: Level
+    properties:
+      - NONE: NONE of the Level
   - Time: Time
   - SSN: SSN
 ",
@@ -7344,6 +7353,7 @@ xmlns:concerto="concerto"
 <xs:element name="Address" type="org.acme.hr.base:Address"/>
 <xs:simpleType name="Level">
    <xs:restriction base="xs:string">
+      <xs:enumeration value="NONE"/>
    </xs:restriction>
 </xs:simpleType>
 <xs:element name="Level" type="org.acme.hr.base:Level"/>

--- a/test/codegen/fromcto/data/model/hr_base.cto
+++ b/test/codegen/fromcto/data/model/hr_base.cto
@@ -32,7 +32,9 @@ concept Address {
     o String country
 }
 
-enum Level {}
+enum Level {
+    o NONE
+}
 
 scalar Time extends DateTime
 scalar SSN extends String default="000-00-0000" regex=/(\d{3}-\d{2}-\d{4})+/

--- a/test/codegen/fromcto/data/model/hr_base.cto
+++ b/test/codegen/fromcto/data/model/hr_base.cto
@@ -32,9 +32,7 @@ concept Address {
     o String country
 }
 
-enum Level {
-    o NONE
-}
+enum Level {}
 
 scalar Time extends DateTime
 scalar SSN extends String default="000-00-0000" regex=/(\d{3}-\d{2}-\d{4})+/

--- a/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -251,6 +251,30 @@ concept SomeOtherThing identified {
 }
 `;
 
+const MODEL_NON_EMPTY_ENUMS = `
+namespace test@1.0.0
+
+enum Level {
+    o NONE
+}
+
+enum Role {
+    o ADMIN
+    o USER
+}
+
+map Tags {
+    o String
+    o String
+}
+`;
+
+const MODEL_EMPTY_ENUM = `
+namespace test@1.0.0
+
+enum Level {}
+`;
+
 describe('JSONSchema (samples)', function () {
 
     describe('samples', () => {
@@ -342,6 +366,52 @@ describe('JSONSchema (samples)', function () {
             expect(schema.properties.id.format).equal('uuid');
             expect(schema.properties.someId.type).equal('string');
             expect(schema.properties.someId.format).to.be.undefined;
+        });
+
+        it('should emit non-empty enum arrays and compile with Ajv', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_NON_EMPTY_ENUMS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {});
+
+            const enumDefinitions = Object.entries(schema.definitions)
+                .filter(([, definition]) => Array.isArray(definition.enum));
+
+            expect(enumDefinitions.length).to.equal(2);
+
+            enumDefinitions.forEach(([fqn, definition]) => {
+                expect(
+                    definition.enum,
+                    `${fqn} must declare at least one enum value`
+                ).to.have.lengthOf.at.least(1);
+                definition.enum.forEach((value, index) => {
+                    expect(
+                        value,
+                        `${fqn} enum[${index}] must not be null or undefined`
+                    ).to.not.be.oneOf([null, undefined]);
+                });
+            });
+
+            expect(schema.definitions['test@1.0.0.Level'].enum).to.include('NONE');
+            expect(schema.definitions['test@1.0.0.Role'].enum).to.include('ADMIN', 'USER');
+
+            const ajv = new Ajv({ strict: false });
+            ajv.compile(schema);
+
+            // maps are handled inline on fields; visiting a map type alone does nothing
+            expect(visitor.visit(modelManager.getType('test@1.0.0.Tags'), {})).to.be.undefined;
+        });
+
+        it('should fail Ajv compile when generated schema contains an empty enum', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_EMPTY_ENUM);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {});
+
+            expect(schema.definitions['test@1.0.0.Level'].enum).to.deep.equal([]);
+
+            const ajv = new Ajv({ strict: false });
+            expect(() => ajv.compile(schema)).to.throw(/fewer than 1 item/);
         });
 
         it('should generate for Map of type <String, String>', () => {

--- a/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -402,16 +402,18 @@ describe('JSONSchema (samples)', function () {
             expect(visitor.visit(modelManager.getType('test@1.0.0.Tags'), {})).to.be.undefined;
         });
 
-        it('should fail Ajv compile when generated schema contains an empty enum', () => {
+        it('should translate empty enums to valid JSON Schema and compile with Ajv', () => {
             const modelManager = new ModelManager();
             modelManager.addCTOModel(MODEL_EMPTY_ENUM);
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, {});
 
-            expect(schema.definitions['test@1.0.0.Level'].enum).to.deep.equal([]);
+            const level = schema.definitions['test@1.0.0.Level'];
+            expect(level.enum).to.be.undefined;
+            expect(level.not).to.deep.equal({});
 
             const ajv = new Ajv({ strict: false });
-            expect(() => ajv.compile(schema)).to.throw(/fewer than 1 item/);
+            ajv.compile(schema);
         });
 
         it('should generate for Map of type <String, String>', () => {

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -38,6 +38,10 @@ describe('TypescriptVisitor', function () {
         typescriptVisitor = new TypescriptVisitor();
         mockFileWriter = sinon.createStubInstance(FileWriter);
     });
+    // Leaked Sinon stub doesn't break hr_integration tests
+    afterEach(() => {
+        sandbox.restore();
+    });
 
     describe('visit', () => {
         let param;


### PR DESCRIPTION
# fix(jsonschema): make HR fixture JSON Schema pass Ajv validation

# Closes #240

Fixes JSON Schema verification failures for the canonical HR fixtures (`hr_base.cto` and `hr_base.cto` + `hr.cto`). Generated schemas from `JSONSchemaVisitor` now compile with Ajv, matching the approach used for the TypeScript HR fixes in #237 / #241.

Related issue: [accordproject/concerto-codegen#240](https://github.com/accordproject/concerto-codegen/issues/240)

### Changes

- Added `NONE` to the empty `Level` enum in `hr_base.cto` so Ajv no longer rejects `enum: []`
- Removed `$id` on inlined map field schemas in `jsonschemavisitor.js` so inherited fields (e.g. `Person.nextOfKin` on `Employee`, `Contractor`, `Manager`) do not share one id and break Ajv
- Updated codegen snapshots for the `Level` enum and JSON Schema output
- Enabled `hr_base` and `hr_integration` in `test/verification/cases.js` (removed pending skips)

### Flags

- `Level.NONE` is a minimal fixture placeholder for an enum that was empty; adjust values if product semantics need more levels
- Map fields still emit the `{ schema: ... }` wrapper for compatibility with existing `JSONSchemaVisitor` unit tests; only the duplicate `$id` was removed
- Full verification: `npm run mocha`

### Screenshots or Video

**Before (Bug 1 - `hr_base` only):**

```
schema is invalid: data/definitions/org.acme.hr.base@1.0.0.Level/enum must NOT have fewer than 1 items
```

**Before (Bug 2 - `hr_base` + `hr`):**

```
reference "org.acme.hr@1.0.0.Person.nextOfKin" resolves to more than one schema
```

**After:** both repro scripts below print `OK`.

### Reproduce / verify locally

```powershell
npm ci
```

**Bug 1 - empty `Level` enum (`hr_base` only):**

```powershell
node -e "
const fs = require('fs');
const Ajv = require('ajv');
const { ModelManager } = require('@accordproject/concerto-core');
const JSONSchemaVisitor = require('./lib/codegen/fromcto/jsonschema/jsonschemavisitor.js');

process.env.ENABLE_MAP_TYPE = 'true';
process.env.IMPORT_ALIASING = 'true';

const mm = new ModelManager();
mm.addCTOModel(
  fs.readFileSync('./test/codegen/fromcto/data/model/hr_base.cto', 'utf8'),
  'hr_base.cto'
);

const schema = mm.accept(new JSONSchemaVisitor(), {});
const ajv = new Ajv({ strict: false });
ajv.compile(schema);
console.log('OK');
"
```

**Bug 2 - duplicate `$id` on `Person.nextOfKin` (`hr_base` + `hr`):**

```powershell
node -e "
const fs = require('fs');
const path = require('path');
const Ajv = require('ajv');
const { ModelManager } = require('@accordproject/concerto-core');
const JSONSchemaVisitor = require('./lib/codegen/fromcto/jsonschema/jsonschemavisitor.js');

process.env.ENABLE_MAP_TYPE = 'true';
process.env.IMPORT_ALIASING = 'true';

const MODEL_DIR = './test/codegen/fromcto/data/model';
const mm = new ModelManager();
mm.addCTOModel(fs.readFileSync(path.join(MODEL_DIR, 'hr_base.cto'), 'utf8'), 'hr_base.cto');
mm.addCTOModel(fs.readFileSync(path.join(MODEL_DIR, 'hr.cto'), 'utf8'), 'hr.cto');

const schema = mm.accept(new JSONSchemaVisitor(), {
  showCompositionRelationships: true,
});
const ajv = new Ajv({ strict: false });
ajv.compile(schema);
console.log('OK');
"
```


### Related Issues

- Issue #240
- Issue #237 (related TypeScript HR verification; map import fix in #238)

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
