### PR TITLE
perf(graph): optimize BFS in findConnectedGraph

### DIFF
--- a/lib/common/graph.js
+++ b/lib/common/graph.js
@@ -106,32 +106,25 @@ class DirectedGraph {
             sourceVertices = [sourceVertices];
         }
 
-        // Track our descent
-        const visited = {};
+        const visited = new Set(sourceVertices);
         const queue = [...sourceVertices];
 
-        // Initialize the state
-        sourceVertices.forEach(v => { visited[v] = true; });
-
-        // Perform a BFS search of the graph.
-        let currentVertex;
-        while (queue.length > 0) {
-            currentVertex = queue[0];
-            queue.shift();
-
-            const edges = this.adjacencyMap[currentVertex] || [];
-
-            edges.forEach(edge => {
-                if (!visited[edge]) {
-                    visited[edge] = true;
-                    queue.push(edge);
+        // BFS using an index pointer
+        for (let i = 0; i < queue.length; i++) {
+            const edges = this.adjacencyMap[queue[i]];
+            if (edges) {
+                for (let j = 0; j < edges.length; j++) {
+                    if (!visited.has(edges[j])) {
+                        visited.add(edges[j]);
+                        queue.push(edges[j]);
+                    }
                 }
-            });
+            }
         }
 
         return new DirectedGraph(Object.fromEntries(
             Object.entries(this.adjacencyMap)
-                .filter(([vertex]) => visited[vertex])
+                .filter(([vertex]) => visited.has(vertex))
         ));
     }
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Optimize the BFS traversal in `DirectedGraph.findConnectedGraph` to eliminate O(n) array re-indexing on each iteration.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
  - Replace `Array.shift()` with an index pointer for O(1) dequeue
  - Replace plain object visited map with `Set` to avoid prototype collisions
  - Replace `forEach` with for-loops to avoid per-iteration closure allocation

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
  - No API or behavioral changes; purely internal performance improvement

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
