### PR TITLE
fix(rust): serialize_datetime_option panics on a None value

### DIFF
--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -867,7 +867,7 @@ class RustVisitor {
             'serialize_datetime(&dt, serializer)'
         );
         parameters.fileWriter.writeLine(2, '},');
-        parameters.fileWriter.writeLine(2, '_ => unreachable!(),');
+        parameters.fileWriter.writeLine(2, 'None => serializer.serialize_none(),');
         parameters.fileWriter.writeLine(1, '}');
         parameters.fileWriter.writeLine(0, '}');
         parameters.fileWriter.writeLine(0, '');

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -5696,7 +5696,7 @@ where
       Some(dt) => {
          serialize_datetime(&dt, serializer)
       },
-      _ => unreachable!(),
+      None => serializer.serialize_none(),
    }
 }
 

--- a/test/codegen/fromcto/rust/rustvisitor.js
+++ b/test/codegen/fromcto/rust/rustvisitor.js
@@ -1339,7 +1339,7 @@ describe('RustVisitor', function () {
                     [2, 'Some(dt) => {'],
                     [3, 'serialize_datetime(&dt, serializer)'],
                     [2, '},'],
-                    [2, '_ => unreachable!(),'],
+                    [2, 'None => serializer.serialize_none(),'],
                     [1, '}'],
                     [0, '}'],
                     [0, ''],


### PR DESCRIPTION
# Closes #250

The Rust code generator emits `serialize_datetime_option` (into the generated
`utils.rs`) with `_ => unreachable!()` for the `None` branch, so serializing a
`None` `Option<DateTime>` panics. This makes it emit `null` instead, matching
the other option serializers in the same file.

### Changes
- `addUtilsModelFile` now generates `None => serializer.serialize_none()` for
  `serialize_datetime_option`, consistent with `serialize_datetime_array_option`
  and the other option serializers.
- Updated the matching unit-test assertion and the codegen snapshot.

### Flags
- One line of real change; no other generated output is affected.
- The bug is in generated code, so the fix belongs here in the codegen rather
  than in the generated `utils.rs`.

### Related Issues
- #250

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:yash/fix-datetime-option-serialize`