### PR TITLE
feat(csharp): add C# support to verification and code generation

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -24,6 +24,7 @@ jobs:
         target:
           - typescript
           - jsonschema
+          - csharp
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -131,14 +131,14 @@ class CSharpVisitor {
             .filter((v, i, a) => a.indexOf(v) === i) // Remove any duplicates from direct imports
             .forEach(namespace => {
                 // concerto.decorator types are provided by the .NET runtime package.
-                if (ModelUtil.parseNamespace(namespace).name === 'concerto.decorator') {
+                if (this.useConcertoRuntime(parameters) && ModelUtil.parseNamespace(namespace).name === 'concerto.decorator') {
                     parameters.fileWriter.writeLine(0, 'using AccordProject.Concerto.Metamodel;');
                     return;
                 }
                 const otherModelFile = modelFile.getModelManager()?.getModelFile(namespace);
                 if (!otherModelFile) {
                     // Couldn't resolve the other model file.
-                    parameters.fileWriter.writeLine(0, `using ${namespacePrefix}${namespace};`);
+                    parameters.fileWriter.writeLine(0, `using ${namespacePrefix}${this.toCSharpNamespace(namespace, parameters)};`);
                     return;
                 }
                 const otherDotNetNamespace = this.getDotNetNamespace(otherModelFile, { ...parameters, namespacePrefix });
@@ -216,14 +216,16 @@ class CSharpVisitor {
         const { name: namespace, version } = ModelUtil.parseNamespace(classDeclaration.getNamespace());
         const name = classDeclaration.getName();
         const identifier = this.toCSharpIdentifier(undefined, name, parameters);
-        parameters.fileWriter.writeLine(0, `[AccordProject.Concerto.Type(Namespace = "${namespace}", Version = ${version ? `"${version}"` : 'null'}, Name = "${name}")]`);
+        if (this.useConcertoRuntime(parameters)) {
+            parameters.fileWriter.writeLine(0, `[AccordProject.Concerto.Type(Namespace = "${namespace}", Version = ${version ? `"${version}"` : 'null'}, Name = "${name}")]`);
 
-        // classDeclaration has any other subtypes
-        if (parameters.useSystemTextJson) {
-            parameters.fileWriter.writeLine(0, '[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]');
-        }
-        if (parameters.useNewtonsoftJson) {
-            parameters.fileWriter.writeLine(0, '[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]');
+            // classDeclaration has any other subtypes
+            if (parameters.useSystemTextJson) {
+                parameters.fileWriter.writeLine(0, '[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]');
+            }
+            if (parameters.useNewtonsoftJson) {
+                parameters.fileWriter.writeLine(0, '[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]');
+            }
         }
         parameters.fileWriter.writeLine(0, `public ${abstract}class ${identifier}${superType}{`);
         const override = namespace === 'concerto' && name === 'Concept' ? 'virtual' : 'override';
@@ -257,7 +259,7 @@ class CSharpVisitor {
         let dotnetNs = '';
         const parsedNamespace = type ? ModelUtil.parseNamespace(ModelUtil.getNamespace(type)).name : null;
         // concerto.decorator base types are provided by the .NET runtime package.
-        if (parsedNamespace === 'concerto.decorator') {
+        if (this.useConcertoRuntime(parameters) && parsedNamespace === 'concerto.decorator') {
             return 'AccordProject.Concerto.Metamodel.';
         }
         // Resolve to dotnet namespace only if its a non system type
@@ -525,7 +527,9 @@ class CSharpVisitor {
 
         let isIdentifier = field.getName() === field.getParent()?.getIdentifierFieldName();
         if (isIdentifier) {
-            parameters.fileWriter.writeLine(1, '[AccordProject.Concerto.Identifier()]');
+            if (this.useConcertoRuntime(parameters)) {
+                parameters.fileWriter.writeLine(1, '[AccordProject.Concerto.Identifier()]');
+            }
             parameters.fileWriter.writeLine(1, '[System.ComponentModel.DataAnnotations.Key]');
         }
 
@@ -583,7 +587,7 @@ class CSharpVisitor {
         const rawDefault = field.isArray()
             ? null
             : (externalFieldType !== undefined ? scalarDefaultValue : field.getDefaultValue());
-        const csDefault = this.formatDefaultLiteral(rawDefault, rawFieldType, !!externalFieldType, field, fieldType);
+        const csDefault = this.formatDefaultLiteral(rawDefault, rawFieldType, !!externalFieldType, field, fieldType, parameters);
         const getset = csDefault != null ? `{ get; set; } = ${csDefault};` : '{ get; set; }';
         const csharpType = this.toCSharpType(fieldType, parameters);
         let isEnum = false;
@@ -761,10 +765,11 @@ class CSharpVisitor {
      * @param {boolean} isScalar - true when the property type is a scalar struct
      * @param {Field} [field] - the field for context when handling enum defaults (optional)
      * @param {string} [resolvedFieldType] - resolved C# property type used for enum qualification
+     * @param {object} [parameters] - visitor parameters
      * @returns {string|null} C# literal string, or null if no default
      * @private
      */
-    formatDefaultLiteral(value, concertoType, isScalar, field, resolvedFieldType) {
+    formatDefaultLiteral(value, concertoType, isScalar, field, resolvedFieldType, parameters) {
         if (value == null) {return null;}
         // Pre-computed C# literal (e.g. UUID default needs System.Guid.Parse, not a bare string)
         if (value?.__csharpLiteral) {return value.__csharpLiteral;}
@@ -774,15 +779,18 @@ class CSharpVisitor {
             try {
                 const fieldType = field.getModelFile().getType(field.getType());
                 if (fieldType?.isEnum?.()) {
-                    // Enum value found; emit Type.Member
-                    // e.g., "EXTERNAL" -> "PartySide.External"
-                    const enumMemberName = camelCase(String(value), { pascalCase: true });
-                    const enumTypeName = resolvedFieldType || this.toCSharpIdentifier(undefined, field.getType());
+                    const enumMemberName = this.toCSharpIdentifier(undefined, String(value), parameters);
+                    const enumTypeName = resolvedFieldType || this.toCSharpIdentifier(undefined, field.getType(), parameters);
                     return `${enumTypeName}.${enumMemberName}`;
                 }
             } catch (e) {
                 // Type resolution failed; fall through to default handling
             }
+        }
+
+        if (concertoType === 'DateTime') {
+            const literal = isScalar ? `new(System.DateTime.Parse("${value}"))` : `System.DateTime.Parse("${value}")`;
+            return literal;
         }
 
         const rawLiteral = concertoType === 'String' ? `"${value}"` : String(value);
@@ -922,22 +930,37 @@ class CSharpVisitor {
      * @return {string} the .NET namespace for the model file
      */
     getDotNetNamespace(modelFile, parameters) {
-        const decorator = modelFile.getDecorator('DotNetNamespace');
-        if (!decorator) {
-            const { name: namespace } = ModelUtil.parseNamespace(modelFile.getNamespace());
-            const result = this.toCSharpNamespace(namespace, parameters);
-            const { namespacePrefix } = parameters;
-            if (namespacePrefix) {
-                return `${namespacePrefix}${result}`;
-            } else {
-                return result;
+        if (this.useConcertoRuntime(parameters)) {
+            const decorator = modelFile.getDecorator('DotNetNamespace');
+            if (decorator) {
+                const args = decorator.getArguments();
+                if (args.length !== 1) {
+                    throw new Error('Malformed @DotNetNamespace decorator');
+                }
+                return args[0];
             }
         }
-        const args = decorator.getArguments();
-        if (args.length !== 1) {
-            throw new Error('Malformed @DotNetNamespace decorator');
+        const { name: namespace } = ModelUtil.parseNamespace(modelFile.getNamespace());
+        const result = this.toCSharpNamespace(namespace, parameters);
+        const { namespacePrefix } = parameters;
+        if (namespacePrefix) {
+            return `${namespacePrefix}${result}`;
         }
-        return args[0];
+        return result;
+    }
+
+    /**
+     * Whether generated C# should reference the AccordProject.Concerto runtime package.
+     * Defaults to true unless useConcertoRuntime is false or CSHARP_USE_CONCERTO_RUNTIME=false.
+     * @param {object} parameters visitor parameters
+     * @returns {boolean} true when Concerto runtime attributes and namespaces should be emitted
+     * @private
+     */
+    useConcertoRuntime(parameters) {
+        if (parameters.useConcertoRuntime !== undefined) {
+            return !!parameters.useConcertoRuntime;
+        }
+        return process.env.CSHARP_USE_CONCERTO_RUNTIME !== 'false';
     }
 
     /**
@@ -988,9 +1011,11 @@ class CSharpVisitor {
         return components.map(component => {
             if (isPascalCase) {
                 return camelCase(component, { pascalCase: true });
-            } else {
-                return component;
             }
+            if (reservedKeywords.includes(component)) {
+                return '_' + component;
+            }
+            return component;
         }).join('.');
     }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "verify:docker": "node scripts/verification/docker-run.js",
         "verify:docker:typescript": "node scripts/verification/docker-run.js typescript",
         "verify:docker:jsonschema": "node scripts/verification/docker-run.js jsonschema",
+        "verify:docker:csharp": "node scripts/verification/docker-run.js csharp",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema'];
+const TARGETS = ['typescript', 'jsonschema', 'csharp'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -690,7 +690,7 @@ public abstract class Event : Concept {
 exports[`codegen #formats check we can convert all formats from namespace versioned CTO, format 'csharp' 3`] = `
 {
   "key": "org.acme.hr.base@1.0.0.cs",
-  "value": "namespace org.acme.hr.base;
+  "value": "namespace org.acme.hr._base;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using AccordProject.Concerto;
@@ -776,7 +776,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
   "value": "namespace org.acme.hr;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using org.acme.hr.base;
+using org.acme.hr._base;
 using AccordProject.Concerto.Metamodel;
 using AccordProject.Concerto;
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "pii")]
@@ -785,7 +785,7 @@ public class pii : AccordProject.Concerto.Metamodel.Decorator {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.pii";
    public bool isPii { get; set; }
-   public org.acme.hr.base.Category category { get; set; }
+   public org.acme.hr._base.Category category { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = "1.0.0", Name = "Info")]
 [System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
@@ -807,7 +807,7 @@ public class Company : Concept {
    public override string _class { get; } = "org.acme.hr@1.0.0.Company";
    [System.ComponentModel.DataAnnotations.RegularExpression(@"abc.*", ErrorMessage = "Invalid characters")]
    public string name { get; set; }
-   public org.acme.hr.base.Address headquarters { get; set; }
+   public org.acme.hr._base.Address headquarters { get; set; }
    public Dictionary<string, string>? companyProperties { get; set; }
    public Dictionary<SSN, Employee>? employeeDirectory { get; set; }
    public Dictionary<SSN, TShirtSizeType>? employeeTShirtSizes { get; set; }
@@ -856,7 +856,7 @@ public abstract class Person : Participant {
    public string firstName { get; set; }
    public string lastName { get; set; }
    public string? middleNames { get; set; }
-   public org.acme.hr.base.Address homeAddress { get; set; }
+   public org.acme.hr._base.Address homeAddress { get; set; }
    public SSN ssn { get; set; } = new("000-00-0000");
    public double height { get; set; }
    public System.DateTime dob { get; set; }
@@ -873,7 +873,7 @@ public class Employee : Person {
    public int numDependents { get; set; }
    public bool retired { get; set; }
    public Department department { get; set; }
-   public org.acme.hr.base.Address officeAddress { get; set; }
+   public org.acme.hr._base.Address officeAddress { get; set; }
    public Equipment[] companyAssets { get; set; }
    public Manager? manager { get; set; }
 }
@@ -911,7 +911,7 @@ public class ChangeOfAddress : Transaction {
    [System.Text.Json.Serialization.JsonPropertyName("$class")]
    public override string _class { get; } = "org.acme.hr@1.0.0.ChangeOfAddress";
    public Person Person { get; set; }
-   public org.acme.hr.base.Address newAddress { get; set; }
+   public org.acme.hr._base.Address newAddress { get; set; }
 }
 [System.Text.Json.Serialization.JsonConverter(typeof(KinNameJsonConverter))]
 public readonly record struct KinName(string Value)

--- a/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -41,6 +41,7 @@ describe('CSharpVisitor', function () {
     let mockFileWriter;
 
     beforeEach(() => {
+        delete process.env.CSHARP_USE_CONCERTO_RUNTIME;
         csharpVisitor = new CSharpVisitor();
         mockFileWriter = sinon.createStubInstance(FileWriter);
         sandbox.stub(ModelUtil, 'isMap').callsFake(() => {
@@ -898,7 +899,7 @@ public class SampleModel : Concept {
             const files = fileWriter.getFilesInMemory();
             const file1 = files.get('org.acme@1.2.3.cs');
             // Enum default values should be emitted as qualified C# enum members
-            file1.should.match(/public Status status \{ get; set; \} = Status.Active;/);
+            file1.should.match(/public Status status \{ get; set; \} = Status.ACTIVE;/);
         });
 
         it('should emit required for non-optional reference fields when flag is enabled', () => {
@@ -938,7 +939,7 @@ public class SampleModel : Concept {
             file1.should.match(/public string\? nick \{ get; set; \}/);
             file1.should.match(/public SSN ssn \{ get; set; \}/);
             file1.should.match(/public required SSN\[\] ssns \{ get; set; \}/);
-            file1.should.match(/public Status status \{ get; set; \} = Status.Active;/);
+            file1.should.match(/public Status status \{ get; set; \} = Status.ACTIVE;/);
             file1.should.match(/public Status state \{ get; set; \}/);
             file1.should.match(/public required Status\[\] states \{ get; set; \}/);
             file1.should.match(/public required Child child \{ get; set; \}/);

--- a/test/verification/csharp.compile.test.js
+++ b/test/verification/csharp.compile.test.js
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const CSharpVisitor = require('../../lib/codegen/fromcto/csharp/csharpvisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+const CSPROJ_TEMPLATE = path.join(__dirname, '../../verification/templates/Verify.csproj');
+
+/**
+ * Return a skip reason when the local dotnet SDK cannot build net8.0 projects.
+ * @returns {string|null} skip reason or null when dotnet 8 is available
+ */
+function getDotnetSkipReason() {
+    const version = spawnSync('dotnet', ['--version'], { encoding: 'utf-8' });
+    if (version.status !== 0) {
+        return 'dotnet SDK not installed';
+    }
+
+    const sdks = spawnSync('dotnet', ['--list-sdks'], { encoding: 'utf-8' });
+    if (!/\b8\./.test(sdks.stdout || '')) {
+        return '.NET 8 SDK required for verification';
+    }
+
+    return null;
+}
+
+const DOTNET_SKIP_REASON = getDotnetSkipReason();
+
+/**
+ * Generate C# from a model and verify it compiles with dotnet build.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to CSharpVisitor
+ */
+async function verifyCSharpCompiles(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new CSharpVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            useConcertoRuntime: false,
+            ...visitorOptions,
+        });
+
+        fs.copyFileSync(CSPROJ_TEMPLATE, path.join(outputDir, 'Verify.csproj'));
+
+        try {
+            execFileSync('dotnet', ['build', 'Verify.csproj', '--nologo', '-v', 'q'], {
+                cwd: outputDir,
+                encoding: 'utf-8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+        } catch (err) {
+            const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+            throw new Error(details || err.message);
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(120000);
+
+    before(function () {
+        applyVerificationEnv();
+        if (DOTNET_SKIP_REASON) {
+            // eslint-disable-next-line no-console
+            console.warn(`Skipping C# verification tests: ${DOTNET_SKIP_REASON}`);
+        }
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = getSkipReason(testCase, 'csharp') || DOTNET_SKIP_REASON;
+        const title = skipReason
+            ? `generated C# from ${testCase.name} compiles with dotnet build (pending: ${skipReason})`
+            : `generated C# from ${testCase.name} compiles with dotnet build`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyCSharpCompiles(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/verification/docker/base/Dockerfile
+++ b/verification/docker/base/Dockerfile
@@ -15,11 +15,17 @@ RUN npm install --no-save \
     @accordproject/concerto-util@^4.1.3 \
     @accordproject/concerto-vocabulary@^4.1.3
 
-# Point the global Concerto CLI at this checkout so PRs test branch codegen.
+# Point the Concerto CLI at this checkout so PRs test branch codegen.
+# concerto-cli resolves @accordproject/concerto-codegen from its own
+# node_modules first, so replace both the global and nested copies.
 RUN npm install -g @accordproject/concerto-cli \
     && GLOBAL_ROOT="$(npm root -g)" \
+    && CODEGEN_LINK=/opt/concerto-codegen \
     && rm -rf "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
-    && ln -s /opt/concerto-codegen "$GLOBAL_ROOT/@accordproject/concerto-codegen"
+    && ln -s "$CODEGEN_LINK" "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
+    && CLI_CODEGEN="$GLOBAL_ROOT/@accordproject/concerto-cli/node_modules/@accordproject/concerto-codegen" \
+    && rm -rf "$CLI_CODEGEN" \
+    && ln -s "$CODEGEN_LINK" "$CLI_CODEGEN"
 
 ENV ENABLE_MAP_TYPE=true \
     IMPORT_ALIASING=true \

--- a/verification/docker/csharp/Dockerfile
+++ b/verification/docker/csharp/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+ENV CSHARP_USE_CONCERTO_RUNTIME=false
+
+RUN apk add --no-cache dotnet8-sdk
+
+COPY verification/docker/csharp/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/csharp/entrypoint.sh
+++ b/verification/docker/csharp/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Generate C# from the corpus and verify with dotnet build.
+set -eu
+
+CLI_TARGET=CSharp
+TARGET_KEY=csharp
+CSPROJ_TEMPLATE=/opt/concerto-codegen/verification/templates/Verify.csproj
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    if [ ! -d "$out" ] || [ -z "$(find "$out" -name '*.cs' -print -quit 2>/dev/null)" ]; then
+        continue
+    fi
+
+    cp "$CSPROJ_TEMPLATE" "$out/Verify.csproj"
+
+    echo "==> VERIFY $case_name with dotnet build"
+    dotnet build "$out/Verify.csproj" --nologo -v q
+done

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -13,7 +13,8 @@
     },
     "csharp": {
         "cli": "CSharp",
-        "baseImage": "mcr.microsoft.com/dotnet/sdk:8.0-alpine",
+        "baseImage": "node:20-alpine",
+        "toolInstall": "apk add --no-cache dotnet8-sdk",
         "tool": "dotnet build",
         "type": "compiled"
     }

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -10,5 +10,11 @@
         "baseImage": "node:20-alpine",
         "tool": "ajv compile",
         "type": "schema"
+    },
+    "csharp": {
+        "cli": "CSharp",
+        "baseImage": "mcr.microsoft.com/dotnet/sdk:8.0-alpine",
+        "tool": "dotnet build",
+        "type": "compiled"
     }
 }

--- a/verification/templates/Verify.csproj
+++ b/verification/templates/Verify.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- Generated models use optional/nullable syntax; verification only checks compile success. -->
+    <NoWarn>$(NoWarn);CS8618;CS8632</NoWarn>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
# C# Code Generation and Verification

This document describes the C# verification work introduced in commit `fcaabbf` (`feat(csharp): add C# support to verification and code generation`). It explains **what changed**, **why each decision was made**, and **how the pieces fit together**.

The goal is to guarantee that generated C# from Concerto models **compiles successfully** under .NET 8, using the same verification pattern already established for TypeScript (`tsc`) and JSON Schema (`ajv`).

---

## Table of contents

1. [High-level summary](#high-level-summary)
2. [Verification architecture](#verification-architecture)
3. [CSharpVisitor changes](#csharpvisitor-changes)
4. [Local Mocha verification tests](#local-mocha-verification-tests)
5. [Docker-based verification (CI)](#docker-based-verification-ci)
6. [Verify.csproj template](#verifycsproj-template)
7. [CI workflow and npm scripts](#ci-workflow-and-npm-scripts)
8. [Snapshot test updates](#snapshot-test-updates)
9. [Running verification locally](#running-verification-locally)
10. [Known limitations and follow-ups](#known-limitations-and-follow-ups)

---

## High-level summary

| Area | What was added or changed |
|------|---------------------------|
| **Codegen** | `CSharpVisitor` gained optional Concerto runtime emission, C# reserved-keyword escaping in namespaces, and fixes for DateTime/enum defaults |
| **Local tests** | `test/verification/csharp.compile.test.js` - generates C# and runs `dotnet build` for 7 model fixtures |
| **Docker** | New `verification/docker/csharp/` image; base image symlink fix so CLI uses checkout codegen |
| **Templates** | `verification/templates/Verify.csproj` - minimal net8.0 project for compile checks |
| **CI** | `.github/workflows/verify-codegen.yml` matrix extended with `csharp` |
| **Scripts** | `npm run verify:docker:csharp` and related entries in `package.json` |

C# as a codegen target already existed in this repository (see prior commits such as `#231`, `#234`, `#236`). This change adds **automated verification** so regressions are caught in CI and locally, mirroring the TypeScript/JSON Schema pipeline from PR `#246`.

---

## Verification architecture

Verification follows a **generate → compile** pipeline:

```
Concerto model (CTO / metamodel)
        │
        ▼
   CSharpVisitor
        │
        ▼
   *.cs files + Verify.csproj
        │
        ▼
   dotnet build  ──► pass / fail
```

There are **two entry points** that share concepts but differ in how codegen is invoked:

| Path | Codegen invoked via | When it runs |
|------|---------------------|--------------|
| **Mocha** (`test/verification/csharp.compile.test.js`) | Direct `CSharpVisitor` import from `lib/` | `npm run test:verify`, pre-push local dev |
| **Docker** (`verification/docker/csharp/entrypoint.sh`) | `concerto compile --target CSharp` CLI | `npm run verify:docker:csharp`, GitHub Actions |

Both paths copy the same `Verify.csproj` template and run `dotnet build`.

### Shared test cases

Model fixtures are defined once in `test/verification/cases.js`:

| Case | Models | Notes |
|------|--------|-------|
| `metamodel` | Concerto metamodel CTO | Same as `concerto compile --metamodel` |
| `hr_base` | `hr_base.cto` | Includes namespace segment `base` (C# keyword) |
| `hr_integration` | `hr_base.cto` + `hr.cto` | Cross-namespace imports, maps, relationships |
| `stringlength` | `stringlength.cto` | Validator decorators |
| `model-base` | `model-base.cto` | Base Concerto types |
| `agreement` | `agreement.cto` | Real-world-style model |
| `circular` | `circular.cto` | Circular type references |

Environment flags applied to all cases (via `applyVerificationEnv()`):

- `ENABLE_MAP_TYPE=true`
- `IMPORT_ALIASING=true`

Per-target skips are supported via `testCase.skip` (string or `{ csharp: 'reason' }`).

### Docker corpus (currently smaller)

`verification/corpus/manifest.json` currently lists only the **metamodel** case. Docker CI validates the CLI path against the largest built-in model. The Mocha suite exercises the broader fixture set. Expanding the Docker corpus to mirror `cases.js` is a natural follow-up.

---

## CSharpVisitor changes

File: `lib/codegen/fromcto/csharp/csharpvisitor.js`

These changes support both **production codegen** (with optional Concerto .NET runtime) and **verification** (standalone POJOs that compile without external NuGet packages).

### 1. Optional Concerto runtime (`useConcertoRuntime`)

**Problem:** Generated C# previously always emitted attributes and types from the `AccordProject.Concerto` NuGet package:

- `[AccordProject.Concerto.Type(...)]`
- `[AccordProject.Concerto.Identifier()]`
- `[AccordProject.Concerto.ConcertoConverterFactorySystem]`
- `using AccordProject.Concerto.Metamodel` for `concerto.decorator` types

Verification builds use a **bare** `.csproj` with no package references. Referencing those types caused hundreds of `CS0234` errors.

**Solution:** Introduced `useConcertoRuntime(parameters)`:

```javascript
useConcertoRuntime(parameters) {
    if (parameters.useConcertoRuntime !== undefined) {
        return !!parameters.useConcertoRuntime;
    }
    return process.env.CSHARP_USE_CONCERTO_RUNTIME !== 'false';
}
```

| Mode | How enabled | Output |
|------|-------------|--------|
| **Runtime on** (default for CLI users) | Default, or `useConcertoRuntime: true` | Full Concerto attributes, runtime JSON converters |
| **Runtime off** (verification) | `useConcertoRuntime: false` or `CSHARP_USE_CONCERTO_RUNTIME=false` | Plain C# classes; still uses `System.Text.Json` attributes where applicable |

Runtime-gated emission sites:

- Class-level `[AccordProject.Concerto.Type]` and converter attributes
- Field-level `[AccordProject.Concerto.Identifier()]`
- `concerto.decorator` namespace → `AccordProject.Concerto.Metamodel` mapping
- `@DotNetNamespace` decorator handling (see below)

**Why default to runtime on:** Existing CLI and production consumers expect Concerto-aware output. Verification explicitly opts out rather than changing the default developer experience.

### 2. `@DotNetNamespace` decorator scope

**Before:** If a model file had `@DotNetNamespace("...")`, that value was **always** used as the .NET namespace.

**After:** The decorator is honoured **only when** `useConcertoRuntime` is true. In verification mode, namespaces are derived from the Concerto namespace via `toCSharpNamespace()`, keeping output predictable and independent of decorator metadata that may target the runtime package layout.

### 3. C# reserved keywords in namespace segments (`toCase`)

**Problem:** The Concerto namespace `org.acme.hr.base` contains `base`, a C# keyword. `namespace org.acme.hr.base;` is invalid C#.

**Solution:** In `toCase()`, non-PascalCase namespace components that match `reservedKeywords` are prefixed with `_`:

```
org.acme.hr.base  →  org.acme.hr._base   (C# namespace)
org.acme.hr.base  →  org.acme.hr.base    (unchanged in Concerto metadata, e.g. Type attribute strings)
```

**Important distinction:**

- **C# namespace / using / qualified types** use escaped names (`_base`)
- **Concerto metadata** (`Namespace = "org.acme.hr.base"`, `$class` FQNs) keep the original Concerto namespace

Snapshot updates in `test/codegen/__snapshots__/codegen.js.snap` reflect this for the `hr_base` / `hr_integration` fixtures.

### 4. Unresolved import namespaces

When an imported namespace cannot be resolved to a model file, the `using` directive now applies `toCSharpNamespace()` so keyword escaping is consistent:

```javascript
`using ${namespacePrefix}${this.toCSharpNamespace(namespace, parameters)};`
```

### 5. DateTime default literals

**Problem:** DateTime field defaults were emitted as raw strings, which is not valid C# for `System.DateTime` properties.

**Solution:** `formatDefaultLiteral()` now handles `DateTime`:

```csharp
// scalar struct
new(System.DateTime.Parse("2020-01-01"))
// plain property
System.DateTime.Parse("2020-01-01")
```

### 6. Enum default literals

**Problem:** Enum defaults used `camelCase` for member names, which could produce invalid or inconsistent C# enum member references.

**Solution:** Enum default values now use `toCSharpIdentifier()` for both the enum type name and member name, respecting PascalCase settings and keyword escaping consistently with the rest of the visitor.

---

## Local Mocha verification tests

File: `test/verification/csharp.compile.test.js`

### Design

Mirrors `test/verification/typescript.compile.test.js`:

1. Load each case from `cases.js` into a `ModelManager`
2. Run `CSharpVisitor` with `FileWriter` into a temp directory
3. Copy `Verify.csproj` into that directory
4. Run `dotnet build Verify.csproj --nologo -v q`
5. Fail the test with compiler output on error

### Key parameters

```javascript
modelManager.accept(new CSharpVisitor(), {
    fileWriter: new FileWriter(outputDir),
    useConcertoRuntime: false,  // no AccordProject.Concerto package required
    ...visitorOptions,
});
```

### .NET SDK detection

Tests **gracefully skip** when .NET 8 is not installed locally:

- Checks `dotnet --version`
- Checks `dotnet --list-sdks` for an `8.x` SDK
- Emits a console warning and uses `it.skip` rather than failing the suite

This avoids blocking contributors who work on non-C# parts of the repo without the SDK installed.

### Timeout

Suite timeout is `120000` ms (2 minutes) because `dotnet build` on first run may restore tooling and compile multiple files.

---

## Docker-based verification (CI)

Docker verification ensures the **Concerto CLI path** (`concerto compile --target CSharp`) produces compilable output, not just the programmatic visitor API used in Mocha.

### File layout

```
verification/
├── corpus/
│   └── manifest.json          # Docker case list (metamodel only today)
├── docker/
│   ├── base/
│   │   ├── Dockerfile         # Node + concerto-cli + checkout symlink
│   │   └── run-case.sh        # Runs concerto compile for one case
│   ├── csharp/
│   │   ├── Dockerfile         # Adds dotnet8-sdk, sets CSHARP_USE_CONCERTO_RUNTIME=false
│   │   └── entrypoint.sh      # Generate all cases, dotnet build each
│   └── targets.json           # Target metadata (cli name, tool, base image hint)
├── templates/
│   └── Verify.csproj
└── work-csharp/               # Output mount (gitignored)
```

### C# target Dockerfile

```dockerfile
ARG BASE_IMAGE=concerto-verify-base:local
FROM ${BASE_IMAGE}

ENV CSHARP_USE_CONCERTO_RUNTIME=false

RUN apk add --no-cache dotnet8-sdk
```

**Why Alpine + `dotnet8-sdk` package:** Keeps the image small while matching the net8.0 target in `Verify.csproj`. The base image is Node Alpine; C# verification adds only the SDK layer.

**Why `CSHARP_USE_CONCERTO_RUNTIME=false` in the image:** Docker uses the CLI, which does not pass `useConcertoRuntime: false` as a parameter. The environment variable is the supported override for CLI-driven builds.

### C# entrypoint flow

For each case in `manifest.json`:

1. `run-case.sh metamodel CSharp csharp /work/metamodel`
2. Skip if no `.cs` files were generated
3. Copy `Verify.csproj` into the output directory
4. `dotnet build /work/metamodel/Verify.csproj --nologo -v q`

### Base Dockerfile: checkout codegen symlink (critical fix)

The base image installs `@accordproject/concerto-cli` globally and symlinks `@accordproject/concerto-codegen` to the PR checkout at `/opt/concerto-codegen`.

**Problem discovered during development:** Symlinking only the **global** `node_modules/@accordproject/concerto-codegen` is insufficient. Node resolves dependencies from `concerto-cli`'s **nested** `node_modules` first, so the CLI was still using the bundled 4.1.x visitor (which always emitted runtime attributes).

**Fix:** Replace **both** copies:

```dockerfile
RUN npm install -g @accordproject/concerto-cli \
    && GLOBAL_ROOT="$(npm root -g)" \
    && CODEGEN_LINK=/opt/concerto-codegen \
    && rm -rf "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
    && ln -s "$CODEGEN_LINK" "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
    && CLI_CODEGEN="$GLOBAL_ROOT/@accordproject/concerto-cli/node_modules/@accordproject/concerto-codegen" \
    && rm -rf "$CLI_CODEGEN" \
    && ln -s "$CODEGEN_LINK" "$CLI_CODEGEN"
```

This ensures PRs test the **branch under review**, not the published npm package - the same intent as the original TypeScript/JSON Schema verification design.

### `scripts/verification/docker-run.js`

Extended `TARGETS` array:

```javascript
const TARGETS = ['typescript', 'jsonschema', 'csharp'];
```

Builds base image → target image → runs container with corpus and work volume mounts. Supports filtering: `node scripts/verification/docker-run.js csharp`.

### `verification/docker/targets.json`

Metadata describing each verification target (CLI name, toolchain, verify command). **Not consumed by build scripts today** - it documents the intended layout for humans and future automation.

All targets share the same Node base image (`concerto-verify-base`, built from `node:20-alpine`). Target-specific tools are added in per-target Dockerfiles:

| Target | Extra toolchain | Verify command |
|--------|-----------------|----------------|
| `typescript` | `npm install -g typescript` | `tsc --noEmit` |
| `jsonschema` | `npm install -g ajv-cli` | `ajv compile` |
| `csharp` | `apk add dotnet8-sdk` | `dotnet build` |

C# entry:

```json
"csharp": {
    "cli": "CSharp",
    "baseImage": "node:20-alpine",
    "toolInstall": "apk add --no-cache dotnet8-sdk",
    "tool": "dotnet build",
    "type": "compiled"
}
```

**Why not `mcr.microsoft.com/dotnet/sdk:8.0-alpine`?** An earlier draft listed the official Microsoft SDK image as the C# `baseImage`. That would require a separate image without Node/concerto-cli, or a much larger multi-stage setup. The implemented design extends the **shared** Node base (same as TypeScript and JSON Schema) and installs .NET via Alpine's `dotnet8-sdk` package for layer reuse and a single concerto-cli install. `baseImage` reflects that shared foundation; `toolInstall` records how .NET is added.

---

## Verify.csproj template

File: `verification/templates/Verify.csproj`

Minimal SDK-style project used only to answer: **does the generated C# compile?**

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <Nullable>disable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
    <NoWarn>$(NoWarn);CS8618;CS8632</NoWarn>
  </PropertyGroup>
</Project>
```

### Design decisions

| Setting | Value | Reason |
|---------|-------|--------|
| `TargetFramework` | `net8.0` | Matches current LTS tooling; Alpine package `dotnet8-sdk` |
| `Nullable` | `disable` | Generated models are not fully nullable-annotated; avoids CS8618 flood |
| `NoWarn CS8618` | suppressed | Non-nullable property warnings when nullable is enabled |
| `NoWarn CS8632` | suppressed | Generated code uses `string?` on optional fields; with nullable disabled, `?` annotations trigger CS8632 |
| No NuGet packages | - | Verification tests **standalone** codegen; runtime package is opt-in for production |
| `TreatWarningsAsErrors` | `false` | Verification checks compile success, not warning-free code |

**Why not add `AccordProject.Concerto` NuGet for verification?** That would only validate the runtime-enabled path. The dual-mode `useConcertoRuntime` design intentionally supports both standalone POJOs and runtime-integrated output; verification focuses on the standalone path because it has no external dependencies and catches the widest set of C# syntax errors.

---

## CI workflow and npm scripts

### GitHub Actions (`.github/workflows/verify-codegen.yml`)

Matrix job `verify-${{ matrix.target }}` now includes:

```yaml
matrix:
  target:
    - typescript
    - jsonschema
    - csharp
```

Each target:

1. Builds the shared base Docker image (cached via GHA)
2. Builds the target-specific Dockerfile with `BASE_IMAGE` build arg
3. Runs the container with corpus + work volume mounts
4. Uploads `verification/work-<target>/` artifacts on failure

`fail-fast: false` so one target failing does not cancel the others.

### npm scripts (`package.json`)

```json
"test:verify": "mocha test/verification --timeout 60000",
"verify:docker": "node scripts/verification/docker-run.js",
"verify:docker:csharp": "node scripts/verification/docker-run.js csharp"
```

(`verify:docker:typescript` and `verify:docker:jsonschema` were already present.)

---

## Snapshot test updates

File: `test/codegen/__snapshots__/codegen.js.snap`

Updated C# snapshots for the HR fixtures after reserved-keyword namespace escaping:

| Before | After |
|--------|-------|
| `namespace org.acme.hr.base;` | `namespace org.acme.hr._base;` |
| `using org.acme.hr.base;` | `using org.acme.hr._base;` |
| `org.acme.hr.base.Address` | `org.acme.hr._base.Address` |

Concerto metadata strings (`Namespace = "org.acme.hr.base"`, `_class` FQNs) are **unchanged**.

**Note:** When updating snapshots, run the full format test or apply targeted edits. Running `mocha --updateSnapshot` with `--grep` on a single format can remove snapshots for tests that did not execute.

---

## Running verification locally

### Mocha (requires .NET 8 SDK)

```bash
npm run test:verify
# or C# only:
npx mocha test/verification/csharp.compile.test.js --timeout 120000
```

### Docker (requires Docker)

```bash
npm run verify:docker:csharp
# or all targets:
npm run verify:docker
```

Rebuild images after changing `verification/docker/base/Dockerfile` or `Verify.csproj`.

### Manual CLI check

```bash
# Runtime-off (verification style)
CSHARP_USE_CONCERTO_RUNTIME=false concerto compile --target CSharp --output ./output --metamodel --offline

# Runtime-on (default production style)
concerto compile --target CSharp --output ./output --model path/to/model.cto
```

---

## Known limitations and follow-ups

1. **Two codegen invocation paths** - Mocha passes `useConcertoRuntime: false` explicitly; Docker relies on `CSHARP_USE_CONCERTO_RUNTIME=false`. Both must stay aligned.

2. **Runtime-enabled path is not compile-verified** - Adding `AccordProject.Concerto` to `Verify.csproj` would enable testing runtime output separately; not in scope for initial verification.

3. **Nullable warnings suppressed, not fixed in codegen** - Optional fields emit `?` annotations regardless of project nullable setting. A future improvement could align codegen nullable syntax with project settings.


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary - will be done in a later PR 
- [x] Merging to `main` from `fork:branchname`