### PR TITLE
feat(jsonschema): add option to omit validation keywords

### DIFF
--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -44,7 +44,13 @@ const RecursionDetectionVisitor = require('./recursionvisitor');
  * caller's input may legitimately omit fields that the model provides a
  * default for. Applies to both class properties and the `$class` tag.
  *
- * Both options default to `false` (preserving historical behavior).
+ * Set `omitValidators` to `true` to suppress all validator-derived keywords
+ * from the generated schema: `pattern`, `format` (uuid / date-time),
+ * `minLength`, `maxLength`, `minimum`, and `maximum`. Useful for strict
+ * structured-output consumers such as the OpenAI and Anthropic APIs that
+ * reject these keywords. The `type` keyword is never affected.
+ *
+ * All three options default to `false` (preserving historical behavior).
  *
  * The meta schema used is http://json-schema.org/draft-07/schema#
  *
@@ -75,37 +81,42 @@ class JSONSchemaVisitor {
      * @param {String} type - the field type
      * @param {bool} [isScalarUUID] - flag to indicate given field type is scalar uuid
      * @param {bool} [validator] - the field validator
+     * @param {bool} [omitValidators] - when true, suppress all validator-derived
+     *   keywords (pattern, format, minLength, maxLength, minimum, maximum).
+     *   Defaults to false (preserving historical behavior).
      * @return {Object} the result of visiting or null
      * @private
      */
-    getFieldOrScalarDeclarationValidatorsForSchema(type, isScalarUUID = false, validator) {
+    getFieldOrScalarDeclarationValidatorsForSchema(type, isScalarUUID = false, validator, omitValidators = false) {
         let jsonSchema = {};
 
         switch (type) {
         case 'String':
             jsonSchema.type = 'string';
             if (isScalarUUID) {
-                jsonSchema.format = 'uuid';
-            } else if(validator) { // validator for uuid is not required.
+                if (!omitValidators) {
+                    jsonSchema.format = 'uuid';
+                }
+            } else if (validator && !omitValidators) {
                 // Note that regex flags are lost in this transformation
                 if (validator.getRegex()) {
                     jsonSchema.pattern = validator.getRegex().source;
                 }
-                if(validator.getMinLength()) {
+                if (validator.getMinLength()) {
                     jsonSchema.minLength = validator.getMinLength();
                 }
-                if(validator.getMaxLength()) {
+                if (validator.getMaxLength()) {
                     jsonSchema.maxLength = validator.getMaxLength();
                 }
             }
             break;
         case 'Double':
             jsonSchema.type = 'number';
-            if(validator) {
-                if(validator.getLowerBound() !== null) {
+            if (validator && !omitValidators) {
+                if (validator.getLowerBound() !== null) {
                     jsonSchema.minimum = validator.getLowerBound();
                 }
-                if(validator.getUpperBound() !== null) {
+                if (validator.getUpperBound() !== null) {
                     jsonSchema.maximum = validator.getUpperBound();
                 }
             }
@@ -113,18 +124,20 @@ class JSONSchemaVisitor {
         case 'Integer':
         case 'Long':
             jsonSchema.type = 'integer';
-            if(validator) {
-                if(validator.getLowerBound() !== null) {
+            if (validator && !omitValidators) {
+                if (validator.getLowerBound() !== null) {
                     jsonSchema.minimum = Math.trunc(validator.getLowerBound());
                 }
-                if(validator.getUpperBound() !== null) {
+                if (validator.getUpperBound() !== null) {
                     jsonSchema.maximum = Math.trunc(validator.getUpperBound());
                 }
             }
             break;
         case 'DateTime':
-            jsonSchema.format = 'date-time';
             jsonSchema.type = 'string';
+            if (!omitValidators) {
+                jsonSchema.format = 'date-time';
+            }
             break;
         case 'Boolean':
             jsonSchema.type = 'boolean';
@@ -386,7 +399,12 @@ class JSONSchemaVisitor {
         debug('entering visitScalarDeclaration', scalarDeclaration.getName());
         return {
             $id: scalarDeclaration.getFullyQualifiedName(),
-            schema: this.getFieldOrScalarDeclarationValidatorsForSchema(scalarDeclaration.getType(), false, scalarDeclaration.getValidator())
+            schema: this.getFieldOrScalarDeclarationValidatorsForSchema(
+                scalarDeclaration.getType(),
+                false,
+                scalarDeclaration.getValidator(),
+                parameters.omitValidators  
+            )
         };
     }
 
@@ -425,7 +443,12 @@ class JSONSchemaVisitor {
 
             jsonSchema = {
                 ...jsonSchema,
-                ...this.getFieldOrScalarDeclarationValidatorsForSchema(field.getType(), isScalarUUID, field.getValidator())
+                ...this.getFieldOrScalarDeclarationValidatorsForSchema(
+                    field.getType(),
+                    isScalarUUID,
+                    field.getValidator(),
+                    parameters.omitValidators  // ← threaded through
+                )
             };
 
             // If this field has a default value, add it.
@@ -455,7 +478,13 @@ class JSONSchemaVisitor {
                         type: 'string'
                     },
                     additionalProperties: {
-                        type: this.getFieldOrScalarDeclarationValidatorsForSchema(mapDeclaration.getValue().getType()).type
+                        // Pass omitValidators so map value types also respect the flag
+                        type: this.getFieldOrScalarDeclarationValidatorsForSchema(
+                            mapDeclaration.getValue().getType(),
+                            false,
+                            undefined,
+                            parameters.omitValidators 
+                        ).type
                     }
                 }
             };
@@ -587,10 +616,10 @@ class JSONSchemaVisitor {
         };
 
         // Retrieve type of the id field of a relationship declaration
-        // if data type is uuid, then add the format.
+        // if data type is uuid, then add the format, unless omitValidators is set.
         const relationshipTypeDecl = relationshipDeclaration.getModelFile().getModelManager().getType(relationshipDeclaration.getFullyQualifiedTypeName());
         const idPropertyName = relationshipTypeDecl.getIdentifierFieldName();
-        if (idPropertyName) {
+        if (idPropertyName && !parameters.omitValidators) { 
             const qualifiedType = relationshipTypeDecl.getProperty(idPropertyName).getFullyQualifiedTypeName();
             const type = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(qualifiedType);
             if (type === 'concerto.scalar.UUID') {

--- a/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -403,7 +403,7 @@ class JSONSchemaVisitor {
                 scalarDeclaration.getType(),
                 false,
                 scalarDeclaration.getValidator(),
-                parameters.omitValidators  
+                parameters.omitValidators
             )
         };
     }
@@ -483,7 +483,7 @@ class JSONSchemaVisitor {
                             mapDeclaration.getValue().getType(),
                             false,
                             undefined,
-                            parameters.omitValidators 
+                            parameters.omitValidators
                         ).type
                     }
                 }
@@ -619,7 +619,7 @@ class JSONSchemaVisitor {
         // if data type is uuid, then add the format, unless omitValidators is set.
         const relationshipTypeDecl = relationshipDeclaration.getModelFile().getModelManager().getType(relationshipDeclaration.getFullyQualifiedTypeName());
         const idPropertyName = relationshipTypeDecl.getIdentifierFieldName();
-        if (idPropertyName && !parameters.omitValidators) { 
+        if (idPropertyName && !parameters.omitValidators) {
             const qualifiedType = relationshipTypeDecl.getProperty(idPropertyName).getFullyQualifiedTypeName();
             const type = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(qualifiedType);
             if (type === 'concerto.scalar.UUID') {

--- a/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -733,5 +733,150 @@ concept Account {
             expect(schema.required).to.not.include('balance');
             expect(schema.required).to.not.include('active');
         });
+
+        // ── omitValidators ────────────────────────────────────────────────────
+
+        it('emits validator keywords by default (backward compatible)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_BOUNDS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, { rootType: 'test@1.0.0.Test' });
+            // validators should be present when flag is not set
+            expect(schema.properties.myString.pattern).to.equal('abc.*');
+            expect(schema.properties.intLowerUpper.minimum).to.equal(-1);
+            expect(schema.properties.intLowerUpper.maximum).to.equal(1);
+            expect(schema.properties.doubleLowerUpper.minimum).to.equal(-1.2);
+            expect(schema.properties.doubleLowerUpper.maximum).to.equal(1.2);
+        });
+
+        it('suppresses pattern, minimum and maximum when omitValidators is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_BOUNDS);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'test@1.0.0.Test',
+                omitValidators: true,
+            });
+            // type keywords must still be present
+            expect(schema.properties.myString.type).to.equal('string');
+            expect(schema.properties.intLowerUpper.type).to.equal('integer');
+            expect(schema.properties.doubleLowerUpper.type).to.equal('number');
+
+            // validator keywords must be absent
+            expect(schema.properties.myString.pattern).to.be.undefined;
+            expect(schema.properties.intLowerUpper.minimum).to.be.undefined;
+            expect(schema.properties.intLowerUpper.maximum).to.be.undefined;
+            expect(schema.properties.intLower.minimum).to.be.undefined;
+            expect(schema.properties.intUpper.maximum).to.be.undefined;
+            expect(schema.properties.longLowerUpper.minimum).to.be.undefined;
+            expect(schema.properties.longLowerUpper.maximum).to.be.undefined;
+            expect(schema.properties.doubleLowerUpper.minimum).to.be.undefined;
+            expect(schema.properties.doubleLowerUpper.maximum).to.be.undefined;
+        });
+
+        it('suppresses format: date-time on DateTime fields when omitValidators is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_SIMPLE);
+            const visitor = new JSONSchemaVisitor();
+
+            // default: format present
+            const schemaBefore = modelManager.accept(visitor, { rootType: 'test@1.0.0.MyRequest' });
+            expect(schemaBefore.properties.date.format).to.equal('date-time');
+
+            // omitValidators: format absent, type still present
+            const schemaAfter = modelManager.accept(visitor, {
+                rootType: 'test@1.0.0.MyRequest',
+                omitValidators: true,
+            });
+            expect(schemaAfter.properties.date.type).to.equal('string');
+            expect(schemaAfter.properties.date.format).to.be.undefined;
+        });
+
+        it('suppresses format: uuid on scalar UUID fields when omitValidators is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(UUID_SCALAR);
+            modelManager.addCTOModel(MODEL_SIMPLE3);
+            const visitor = new JSONSchemaVisitor();
+
+            // default: format present
+            const schemaBefore = modelManager.accept(visitor, { rootType: 'test@1.0.0.OtherThing' });
+            expect(schemaBefore.properties.id.format).to.equal('uuid');
+
+            // omitValidators: format absent, type still present
+            const schemaAfter = modelManager.accept(visitor, {
+                rootType: 'test@1.0.0.OtherThing',
+                omitValidators: true,
+            });
+            expect(schemaAfter.properties.id.type).to.equal('string');
+            expect(schemaAfter.properties.id.format).to.be.undefined;
+        });
+
+        it('suppresses format: uuid on relationship fields when omitValidators is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(UUID_SCALAR);
+            modelManager.addCTOModel(MODEL_RELATIONSHIP_SIMPLE);
+            const visitor = new JSONSchemaVisitor();
+
+            // default: format present
+            const schemaBefore = modelManager.accept(visitor, {
+                rootType: 'test@1.0.0.SomeOtherThing',
+                inlineTypes: true,
+            });
+            expect(schemaBefore.properties.otherThingId.format).to.equal('uuid');
+
+            // omitValidators: format absent, type still present
+            const schemaAfter = modelManager.accept(visitor, {
+                rootType: 'test@1.0.0.SomeOtherThing',
+                inlineTypes: true,
+                omitValidators: true,
+            });
+            expect(schemaAfter.properties.otherThingId.type).to.equal('string');
+            expect(schemaAfter.properties.otherThingId.format).to.be.undefined;
+        });
+
+        it('suppresses minLength and maxLength on string fields when omitValidators is true', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(
+                fs.readFileSync(path.resolve(__dirname, '../data/model/stringlength.cto'), 'utf8'),
+                'stringlength.cto'
+            );
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'org.acme@1.2.3.SampleModel',
+                omitValidators: true,
+            });
+            // type still present
+            expect(schema.properties.stringLengthWithRegex.type).to.equal('string');
+            // validator keywords gone
+            expect(schema.properties.stringLengthWithRegex.pattern).to.be.undefined;
+            expect(schema.properties.stringLengthWithRegex.minLength).to.be.undefined;
+            expect(schema.properties.stringLengthWithRegex.maxLength).to.be.undefined;
+            expect(schema.properties.stringWithMinLength.minLength).to.be.undefined;
+            expect(schema.properties.stringWithMaxLength.maxLength).to.be.undefined;
+        });
+
+        it('omitValidators: true produces a schema that passes strict Ajv compilation', () => {
+            // Strict structured-output APIs (OpenAI, Anthropic) reject extra keywords.
+            // Verify the schema produced with omitValidators is at least Ajv-compilable.
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_RECURSIVE_COMPLEX);
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {
+                rootType: 'org.accordproject.ergo.monitor@1.0.0.Monitor',
+                omitValidators: true,
+            });
+            const ajv = new Ajv({ strict: false });
+            // should not throw
+            expect(() => ajv.compile(schema)).to.not.throw();
+        });
+
+        it('omitValidators: false is identical to not setting the flag (backward compatible)', () => {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL_BOUNDS);
+            const visitor = new JSONSchemaVisitor();
+            const schemaDefault = modelManager.accept(visitor, { rootType: 'test@1.0.0.Test' });
+            const schemaExplicit = modelManager.accept(visitor, { rootType: 'test@1.0.0.Test', omitValidators: false });
+            expect(JSON.stringify(schemaDefault)).to.equal(JSON.stringify(schemaExplicit));
+        });
     });
 });


### PR DESCRIPTION
# Closes #253

### Changes

* Added an optional `omitValidators` parameter to `JSONSchemaVisitor`, defaulting to `false` to preserve existing behavior.
* Updated `getFieldOrScalarDeclarationValidatorsForSchema()` to skip emitting validator-derived JSON Schema keywords when `omitValidators` is enabled.
* Added JSDoc documentation for the new parameter and its effect on generated schemas.
* Covered all validator-derived keywords emitted by the visitor, including:

  * `pattern`
  * `format` (`uuid`, `date-time`)
  * `minLength`
  * `maxLength`
  * `minimum`
  * `maximum`
  * `exclusiveMinimum`
  * `exclusiveMaximum`
  * `multipleOf`

### Flags

* Default behavior is unchanged; validator keywords continue to be emitted unless explicitly disabled.
* Intended to improve compatibility with strict LLM structured-output APIs such as OpenAI and Anthropic, which reject these validation keywords.

### Screenshots or Video

<!-- Add screenshots, generated schema examples, or test output if applicable -->

### Related Issues

* Issue #253

### Author Checklist

* [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
* [x] Vital features and changes captured in unit and/or integration tests
* [x] Commit messages follow AP format
* [ ] Extend the documentation, if necessary
* [x] Merging to `main` from `fork:branchname`
