### PR TITLE
Add GraphQL and Protobuf Docker verification targets

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -24,6 +24,8 @@ jobs:
         target:
           - typescript
           - jsonschema
+          - graphql
+          - protobuf
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
         "verify:docker": "node scripts/verification/docker-run.js",
         "verify:docker:typescript": "node scripts/verification/docker-run.js typescript",
         "verify:docker:jsonschema": "node scripts/verification/docker-run.js jsonschema",
+        "verify:docker:graphql": "node scripts/verification/docker-run.js graphql",
+        "verify:docker:protobuf": "node scripts/verification/docker-run.js protobuf",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/verification/docker/graphql/Dockerfile
+++ b/verification/docker/graphql/Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+RUN npm install -g graphql@16
+
+COPY verification/docker/graphql/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/graphql/entrypoint.sh
+++ b/verification/docker/graphql/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Generate GraphQL from the corpus and verify SDL with graphql buildSchema.
+set -eu
+
+CLI_TARGET=GraphQL
+TARGET_KEY=graphql
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    schema="${out}/model.gql"
+    if [ ! -f "$schema" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with graphql"
+    NODE_PATH="$(npm root -g)" node -e '
+        const fs = require("fs");
+        const { buildSchema } = require("graphql");
+        buildSchema(fs.readFileSync(process.argv[1], "utf8"));
+    ' "$schema"
+done

--- a/verification/docker/protobuf/Dockerfile
+++ b/verification/docker/protobuf/Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+RUN apk add --no-cache protobuf protobuf-dev
+
+COPY verification/docker/protobuf/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/protobuf/entrypoint.sh
+++ b/verification/docker/protobuf/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Generate Protobuf from the corpus and verify with protoc.
+set -eu
+
+CLI_TARGET=Protobuf
+TARGET_KEY=protobuf
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    proto_files=$(find "$out" -name '*.proto' | sort)
+    if [ -z "$proto_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with protoc"
+    # shellcheck disable=SC2086
+    protoc -I"$out" -I/usr/include --descriptor_set_out=/dev/null $proto_files
+done

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -10,5 +10,17 @@
         "baseImage": "node:20-alpine",
         "tool": "ajv compile",
         "type": "schema"
+    },
+    "graphql": {
+        "cli": "GraphQL",
+        "baseImage": "node:20-alpine",
+        "tool": "graphql buildSchema",
+        "type": "schema"
+    },
+    "protobuf": {
+        "cli": "Protobuf",
+        "baseImage": "node:20-alpine",
+        "tool": "protoc",
+        "type": "schema"
     }
 }


### PR DESCRIPTION
# Add GraphQL and Protobuf Docker verification targets

Introduced new verification targets for GraphQL and Protobuf in the Docker setup, following the same pattern as the existing TypeScript and JSON Schema targets. 

### Changes

- Added `verification/docker/graphql/` - generates `model.gql` via `concerto compile --target GraphQL` and validates SDL with `graphql` `buildSchema`
- Added `verification/docker/protobuf/` - generates `.proto` files via `concerto compile --target Protobuf` and validates with `protoc` (Alpine `protobuf` + `protobuf-dev` for Google well-known types)
- Extended `verification/docker/targets.json` with `graphql` and `protobuf` metadata
- Extended the `verify-codegen` CI workflow matrix to include `graphql` and `protobuf`
- Extended `scripts/verification/docker-run.js` and `package.json` scripts (`verify:docker:graphql`, `verify:docker:protobuf`)

### Flags

- Protobuf verification may emit a harmless `protoc` warning for an unused `google/protobuf/timestamp.proto` import on the metamodel output; this does not fail the build
- Corpus remains limited to the metamodel case only; additional fixture cases can be added to `verification/corpus/manifest.json` later as codegen gaps are closed


### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary - shall be done 
- [x] Merging to `main` from `fork:branchname`

### Test plan

- [x] `npm run verify:docker:graphql` passes locally
- [x] `npm run verify:docker:protobuf` passes locally
- [x] `npm run verify:docker` runs all four targets successfully
