### PR TITLE
BREAKING(codegen): change DateTime type to string in TypeScript generation

### DIFF
--- a/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -420,7 +420,7 @@ class TypescriptVisitor {
     toTsType(type, useInterface, useUnion) {
         switch (type) {
         case 'DateTime':
-            return 'Date';
+            return 'string';
         case 'Boolean':
             return 'boolean';
         case 'String':

--- a/test/codegen/__snapshots__/codegen.js.snap
+++ b/test/codegen/__snapshots__/codegen.js.snap
@@ -6810,13 +6810,13 @@ export interface IParticipant extends IConcept {
 export type ParticipantUnion = IPerson;
 
 export interface ITransaction extends IConcept {
-   $timestamp: Date;
+   $timestamp: string;
 }
 
 export type TransactionUnion = IChangeOfAddress;
 
 export interface IEvent extends IConcept {
-   $timestamp: Date;
+   $timestamp: string;
 }
 
 export type EventUnion = ICompanyEvent;
@@ -6873,7 +6873,7 @@ export interface IAddress extends IConcept {
 export enum Level {
 }
 
-export type Time = Date;
+export type Time = string;
 
 export type SSN = string;
 
@@ -6964,7 +6964,7 @@ export interface IPerson extends IParticipant {
    homeAddress: IAddress;
    ssn: SSN;
    height: number;
-   dob: Date;
+   dob: string;
    nextOfKin: NextOfKin;
 }
 

--- a/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -550,7 +550,7 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitScalarDeclaration(mockScalarDeclaration, param);
 
             param.fileWriter.writeLine.calledOnce.should.be.ok;
-            param.fileWriter.writeLine.withArgs(0, 'export type RegistrationDate = Date;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type RegistrationDate = string;\n').calledOnce.should.be.ok;
         });
     });
 
@@ -944,7 +944,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, Date>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, string>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <String, Address>', () => {
@@ -1010,7 +1010,7 @@ describe('TypescriptVisitor', function () {
 
             typescriptVisitor.visitMapDeclaration(mockMapDeclaration, param);
 
-            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<Date, IAddress>;\n').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(0, 'export type Map1 = Map<string, IAddress>;\n').calledOnce.should.be.ok;
         });
 
         it('should write a line with the name, key and value of the map <String, Concept>', () => {
@@ -1172,8 +1172,8 @@ describe('TypescriptVisitor', function () {
     });
 
     describe('toTsType', () => {
-        it('should return Date for DateTime', () => {
-            typescriptVisitor.toTsType('DateTime').should.deep.equal('Date');
+        it('should return string for DateTime', () => {
+            typescriptVisitor.toTsType('DateTime').should.deep.equal('string');
         });
         it('should return boolean for Boolean', () => {
             typescriptVisitor.toTsType('Boolean').should.deep.equal('boolean');


### PR DESCRIPTION
# fix(typescript): map Concerto DateTime to string in generated types

# Closes #257 

When generating TypeScript interfaces from Concerto models, the `DateTime` primitive was mapped to the TypeScript `Date` type. In JSON and at runtime, DateTime values are represented as ISO-8601 strings (for example, `"2026-06-27T13:14:00.000Z"`). This mismatch caused strict TypeScript compilation errors when logic code assigned values such as `new Date().toISOString()` to DateTime fields a common pattern in Template Playground logic files.

This PR updates `toTsType` in `TypescriptVisitor` to map `DateTime` to `string`, aligning generated types with how Concerto data is actually serialized and consumed over JSON.

### Changes

- Map the Concerto `DateTime` primitive to `string` instead of `Date` in `TypescriptVisitor.toTsType` (`lib/codegen/fromcto/typescript/typescriptvisitor.js`)
- Update generated TypeScript output for DateTime fields, scalar aliases (e.g. `Time`), and map key/value types (e.g. `Map<string, string>` instead of `Map<string, Date>`)
- Update unit tests in `test/codegen/fromcto/typescript/typescriptvisitor.js` for scalar declarations, map declarations, and `toTsType`
- Update codegen snapshot expectations in `test/codegen/__snapshots__/codegen.js.snap` for affected interfaces (`ITransaction`, `IEvent`, `IPerson`, etc.)

### Flags

- **Breaking change for TypeScript consumers:** Any project that relied on generated interfaces typing DateTime fields as `Date` will need to regenerate types and update code that assigns `Date` objects directly. JSON-backed workflows (Template Playground, Cicero logic, etc.) are the intended beneficiaries and should require no runtime changes.
- **`string` vs `Date | string`:** `string` was chosen deliberately because Concerto JSON serialization always represents DateTime as an ISO-8601 string. A union type would imply both forms are equally common at runtime, which is not the case for JSON payloads.
- **Scope limited to TypeScript:** Other language targets (Java, C#, Rust, etc.) are unchanged and continue to use their own native date/time types.
- **No documentation update required:** This is an internal codegen behavior fix; generated output changes are reflected in tests and snapshots.


**Before (generated TypeScript):**

```typescript
export interface ITransaction extends IConcept {
   $timestamp: Date;
}

export interface IPerson extends IParticipant {
   dob: Date;
}
```

**After (generated TypeScript):**

```typescript
export interface ITransaction extends IConcept {
   $timestamp: string;
}

export interface IPerson extends IParticipant {
   dob: string;
}
```


### Related Issues

- Issue #257 
- [accordproject/template-playground#928](https://github.com/accordproject/template-playground/issues/928) (downstream context: Template Playground logic files failing strict TypeScript checks when returning ISO timestamp strings)

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary (not required for this change)
- [x] Merging to `main` from `fork:branchname`
