### PR TITLE
feat(verification): add C# support for Docker-based verification

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -26,6 +26,7 @@ jobs:
           - jsonschema
           - graphql
           - protobuf
+          - csharp
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "verify:docker:jsonschema": "node scripts/verification/docker-run.js jsonschema",
         "verify:docker:graphql": "node scripts/verification/docker-run.js graphql",
         "verify:docker:protobuf": "node scripts/verification/docker-run.js protobuf",
+        "verify:docker:csharp": "node scripts/verification/docker-run.js csharp",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/test/verification/cases.js
+++ b/test/verification/cases.js
@@ -26,7 +26,7 @@ const MODEL_DIR = path.join(__dirname, '../codegen/fromcto/data/model');
  * Each case loads one fixture (or valid combination) into its own ModelManager.
  * Do not combine unrelated CTO files — some share namespaces or have import deps.
  *
- * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...' }`.
+ * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...' }`.
  */
 const CASES = [
     {

--- a/test/verification/csharp.compile.test.js
+++ b/test/verification/csharp.compile.test.js
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const CSharpVisitor = require('../../lib/codegen/fromcto/csharp/csharpvisitor.js');
+
+const {
+    CASES,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+// C# verification is skipped for every case: the generated C# references the
+// AccordProject.Concerto runtime package (attributes such as
+// [AccordProject.Concerto.Type] and the ConcertoConverterFactorySystem converter),
+// so a standalone `dotnet build` cannot resolve those types. Remove this skip
+// once the C# codegen can emit runtime-independent output.
+const CSHARP_SKIP_REASON = 'C# codegen emits AccordProject.Concerto runtime references; standalone dotnet build not yet supported';
+
+/**
+ * Generate C# from a model and verify it compiles with dotnet build.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to CSharpVisitor
+ */
+async function verifyCSharpCompiles(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new CSharpVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        fs.writeFileSync(
+            path.join(outputDir, 'Verify.csproj'),
+            [
+                '<Project Sdk="Microsoft.NET.Sdk">',
+                '  <PropertyGroup>',
+                '    <TargetFramework>net8.0</TargetFramework>',
+                '    <Nullable>enable</Nullable>',
+                '    <ImplicitUsings>enable</ImplicitUsings>',
+                '  </PropertyGroup>',
+                '</Project>',
+                '',
+            ].join('\n')
+        );
+
+        try {
+            execFileSync('dotnet', ['build', 'Verify.csproj', '--nologo', '-v', 'q'], {
+                cwd: outputDir,
+                encoding: 'utf-8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+        } catch (err) {
+            const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+            throw new Error(details || err.message);
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(120000);
+
+    before(function () {
+        applyVerificationEnv();
+    });
+
+    CASES.forEach(function (testCase) {
+        // All C# cases are skipped for now; see CSHARP_SKIP_REASON above.
+        it.skip(
+            `generated C# from ${testCase.name} compiles with dotnet build (pending: ${CSHARP_SKIP_REASON})`,
+            async function () {
+                const modelManager = createModelManager(testCase);
+                await verifyCSharpCompiles(modelManager, testCase.visitorOptions || {});
+            }
+        );
+    });
+});

--- a/verification/corpus/manifest.json
+++ b/verification/corpus/manifest.json
@@ -9,6 +9,9 @@
             "compile": {
                 "metamodel": true,
                 "offline": true
+            },
+            "skip": {
+                "csharp": "generated C# references AccordProject.Concerto runtime types (e.g. ConcertoConverterFactorySystem) that are not available for a standalone dotnet build"
             }
         }
     ]

--- a/verification/docker/csharp/Dockerfile
+++ b/verification/docker/csharp/Dockerfile
@@ -1,0 +1,21 @@
+# Pull the .NET 8 SDK from the official Alpine image (proposal: dotnet/sdk:8.0-alpine)
+# and layer it onto the shared Node-based verify base, which provides the Concerto
+# CLI + branch codegen used to generate the C# before `dotnet build`.
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet
+FROM ${BASE_IMAGE}
+
+# Runtime libraries required by the .NET SDK on Alpine (musl).
+RUN apk add --no-cache libstdc++ icu-libs
+
+# Copy the SDK from the official image.
+COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet \
+    PATH="/usr/share/dotnet:${PATH}" \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+COPY verification/docker/csharp/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/csharp/entrypoint.sh
+++ b/verification/docker/csharp/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Generate C# from the corpus and verify it compiles with dotnet build.
+set -eu
+
+CLI_TARGET=CSharp
+TARGET_KEY=csharp
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    cs_files=$(find "$out" -name '*.cs' | sort)
+    if [ -z "$cs_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with dotnet build"
+    cat > "$out/Verify.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>
+EOF
+    dotnet build "$out/Verify.csproj" --nologo
+done

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -22,5 +22,11 @@
         "baseImage": "node:20-alpine",
         "tool": "protoc",
         "type": "schema"
+    },
+    "csharp": {
+        "cli": "CSharp",
+        "baseImage": "dotnet/sdk:8.0-alpine",
+        "tool": "dotnet build",
+        "type": "compiled"
     }
 }


### PR DESCRIPTION
Add C# as a verification target in the Docker and test setup

- Introduced C# as a new target in the Docker verification setup.
- Updated package.json, Dockerfiles, and entrypoint scripts to support C# code generation and compilation.
- Added tests for verifying C# compilation, currently marked as skipped due to runtime dependencies.
- Enhanced the verification manifest to include C# skip reasons.

This commit expands the verification capabilities to include C#, ensuring a consistent environment for testing and validation.

### Changes

- Registered the `csharp` target in `verification/docker/targets.json` using the `dotnet/sdk:8.0-alpine` base image, the `dotnet build` tool, and the `compiled` verification type.
- Added `verification/docker/csharp/Dockerfile`, a multi-stage build that pulls the .NET 8 SDK from `dotnet/sdk:8.0-alpine` and layers it onto the shared Node based verify base so the Concerto CLI and branch codegen remain available for generation before compilation.
- Added `verification/docker/csharp/entrypoint.sh` that generates C# for each corpus case, writes a minimal `Verify.csproj`, and compiles the output with `dotnet build`.
- Added the `csharp` target to the `TARGETS` list in `scripts/verification/docker-run.js`.
- Added the `csharp` target to the CI matrix in `.github/workflows/verify-codegen.yml`.
- Added the `verify:docker:csharp` script to `package.json`.
- Added `test/verification/csharp.compile.test.js`, mirroring the TypeScript verification test, with every case skipped for now.
- Updated the skip documentation comment in `test/verification/cases.js` to include the `csharp` target key.
- Added a `csharp` skip reason for the `metamodel` case in `verification/corpus/manifest.json`.

### Flags

- C# verification is intentionally skipped for all cases at this time. The generated C# references the AccordProject.Concerto runtime package (for example the `[AccordProject.Concerto.Type]` attribute and the `ConcertoConverterFactorySystem` converter), so a standalone `dotnet build` cannot resolve those types yet.
- The Docker image was not built locally because the Docker daemon was not running during development. CI will build and run the image. The `csharp` job will build successfully and report a skip for the only corpus case.
- No changes were made to the C# code generator itself. This PR only wires C# into the verification setup.


### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`

