### PR TITLE
feat(verification): add Java support for Docker-based verification

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -28,6 +28,7 @@ jobs:
           - protobuf
           - csharp
           - rust
+          - java
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ npm-debug.log*
 output
 verification/work
 verification/work-*
+verification/templates/jackson-annotations-*.jar
 
 # Runtime data
 pids

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "verify:docker:protobuf": "node scripts/verification/docker-run.js protobuf",
         "verify:docker:csharp": "node scripts/verification/docker-run.js csharp",
         "verify:docker:rust": "node scripts/verification/docker-run.js rust",
+        "verify:docker:java": "node scripts/verification/docker-run.js java",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/test/verification/cases.js
+++ b/test/verification/cases.js
@@ -26,7 +26,7 @@ const MODEL_DIR = path.join(__dirname, '../codegen/fromcto/data/model');
  * Each case loads one fixture (or valid combination) into its own ModelManager.
  * Do not combine unrelated CTO files — some share namespaces or have import deps.
  *
- * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...' }`.
+ * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...', java: '...' }`.
  */
 const CASES = [
     {
@@ -55,6 +55,7 @@ const CASES = [
             // // protobuf: 'scalar map keys (e.g. SSN) are not valid Proto3 map key types',
             graphql: 'map types emit invalid GraphQL SDL (key/value field syntax)',
             rust: 'map declarations reference scalar key/value types (e.g. SSN, Time) that the Rust visitor does not emit, so cargo check fails',
+            java: 'map declarations reference scalar key/value types (e.g. SSN, Time) that the Java visitor does not emit, so javac fails',
         },
     },
     {

--- a/test/verification/java.compile.test.js
+++ b/test/verification/java.compile.test.js
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const https = require('https');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const JavaVisitor = require('../../lib/codegen/fromcto/java/javavisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+const JACKSON_VERSION = '2.17.2';
+const JACKSON_JAR = path.join(
+    __dirname,
+    '../../verification/templates',
+    `jackson-annotations-${JACKSON_VERSION}.jar`
+);
+const JACKSON_URL = `https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/${JACKSON_VERSION}/jackson-annotations-${JACKSON_VERSION}.jar`;
+
+/**
+ * Download the Jackson annotations JAR used by generated Java code.
+ * @returns {Promise<void>} resolves when the JAR has been written to disk
+ */
+function downloadJacksonJar() {
+    return new Promise((resolve, reject) => {
+        fs.mkdirSync(path.dirname(JACKSON_JAR), { recursive: true });
+        const file = fs.createWriteStream(JACKSON_JAR);
+        https.get(JACKSON_URL, (response) => {
+            if (response.statusCode !== 200) {
+                reject(new Error(`Failed to download Jackson annotations (${response.statusCode})`));
+                return;
+            }
+            response.pipe(file);
+            file.on('finish', () => {
+                file.close(resolve);
+            });
+        }).on('error', reject);
+    });
+}
+
+/**
+ * Return the path to the Jackson annotations JAR, downloading it if needed.
+ * @returns {Promise<string>} absolute path to the JAR
+ */
+async function ensureJacksonJar() {
+    if (!fs.existsSync(JACKSON_JAR)) {
+        await downloadJacksonJar();
+    }
+    return JACKSON_JAR;
+}
+
+/**
+ * Collect generated Java source files under a directory tree.
+ * @param {string} dir root directory
+ * @returns {string[]} absolute paths to .java files
+ */
+function collectJavaFiles(dir) {
+    const files = [];
+    for (const entry of fs.readdirSync(dir)) {
+        const filePath = path.join(dir, entry);
+        if (fs.statSync(filePath).isDirectory()) {
+            files.push(...collectJavaFiles(filePath));
+        } else if (entry.endsWith('.java')) {
+            files.push(filePath);
+        }
+    }
+    return files;
+}
+
+/**
+ * Return a skip reason when javac is not available.
+ * @returns {string|null} skip reason or null when javac is available
+ */
+function getJavacSkipReason() {
+    const version = spawnSync('javac', ['-version'], { encoding: 'utf-8' });
+    if (version.error || version.status !== 0) {
+        return 'javac (JDK) not installed';
+    }
+    return null;
+}
+
+const JAVAC_SKIP_REASON = getJavacSkipReason();
+let jacksonJar;
+
+/**
+ * Generate Java from a model and verify it compiles with javac.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to JavaVisitor
+ */
+async function verifyJavaCompiles(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new JavaVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        const javaFiles = collectJavaFiles(outputDir);
+        if (javaFiles.length === 0) {
+            return;
+        }
+
+        try {
+            execFileSync('javac', ['-cp', jacksonJar, ...javaFiles], {
+                cwd: outputDir,
+                encoding: 'utf-8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+        } catch (err) {
+            const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+            throw new Error(details || err.message);
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(120000);
+
+    before(async function () {
+        applyVerificationEnv();
+        if (JAVAC_SKIP_REASON) {
+            // eslint-disable-next-line no-console
+            console.warn(`Skipping Java verification tests: ${JAVAC_SKIP_REASON}`);
+            return;
+        }
+        jacksonJar = await ensureJacksonJar();
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = getSkipReason(testCase, 'java') || JAVAC_SKIP_REASON;
+        const title = skipReason
+            ? `generated Java from ${testCase.name} compiles with javac (pending: ${skipReason})`
+            : `generated Java from ${testCase.name} compiles with javac`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyJavaCompiles(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/verification/docker/java/Dockerfile
+++ b/verification/docker/java/Dockerfile
@@ -1,0 +1,19 @@
+# Pull the JDK from the official Alpine image (eclipse-temurin:17-jdk-alpine)
+# and layer it onto the shared Node-based verify base, which provides the Concerto
+# CLI + branch codegen used to generate the Java before `javac`.
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM eclipse-temurin:17-jdk-alpine AS jdk
+FROM ${BASE_IMAGE}
+
+COPY --from=jdk /opt/java/openjdk /opt/java/openjdk
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}"
+
+RUN apk add --no-cache wget \
+    && wget -q -O /opt/jackson-annotations.jar \
+    https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.17.2/jackson-annotations-2.17.2.jar
+
+COPY verification/docker/java/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/java/entrypoint.sh
+++ b/verification/docker/java/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Generate Java from the corpus and verify it compiles with javac.
+set -eu
+
+CLI_TARGET=Java
+TARGET_KEY=java
+JACKSON="${JACKSON_JAR:-/opt/jackson-annotations.jar}"
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    java_files=$(find "$out" -name '*.java' | sort)
+    if [ -z "$java_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with javac"
+    # shellcheck disable=SC2086
+    javac -cp "$JACKSON" $java_files
+done

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -34,5 +34,11 @@
         "baseImage": "rust:alpine",
         "tool": "cargo check",
         "type": "compiled"
+    },
+    "java": {
+        "cli": "Java",
+        "baseImage": "eclipse-temurin:17-jdk-alpine",
+        "tool": "javac",
+        "type": "compiled"
     }
 }


### PR DESCRIPTION
# Add Java to Docker and local verification

This pull request expands verification to include Java alongside the existing compiled targets (TypeScript, Rust, and C#). Generated Java is compiled with `javac` using Jackson annotations on the classpath, matching what the Java visitor emits today.

### Changes

- Added Java to the Docker verification matrix with `eclipse-temurin:17-jdk-alpine` and `javac` as the compile step
- Created `verification/docker/java/Dockerfile` and `verification/docker/java/entrypoint.sh` to generate and compile Java from the verification corpus
- Registered Java in `verification/docker/targets.json` with CLI target `Java` and type `compiled`
- Added `verify:docker:java` to `package.json` and included `java` in `scripts/verification/docker-run.js`
- Extended `.github/workflows/verify-codegen.yml` CI matrix with the `java` target
- Added `test/verification/java.compile.test.js` to generate Java locally and verify compilation with `javac`
- Downloads `jackson-annotations` from Maven Central on first local test run and during Docker image build
- Updated `test/verification/cases.js` with a per-case skip for `hr_integration` when scalar map key/value types are not emitted as Java classes
- Updated `verification/corpus/manifest.json` so the metamodel case runs for Java in Docker (C# remains skipped)

### Flags

- Generated Java references Jackson annotation types (`@JsonTypeInfo`, `@JsonIgnoreProperties`, and others), so `javac` requires `jackson-annotations` on the classpath
- The Jackson JAR is not committed; it is downloaded into `verification/templates/` on first local test run (gitignored) and fetched in the Docker image at build time
- `hr_integration` is skipped in local Mocha tests because the Java visitor does not emit scalar types such as `SSN` and `Time` referenced by map declarations
- `npm run verify:docker:java` requires a running Docker daemon (for example Docker Desktop on Windows)


### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
