### PR TITLE
feat(verification): add OData support for Docker-based verification

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -29,6 +29,7 @@ jobs:
           - csharp
           - rust
           - java
+          - odata
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "verify:docker:csharp": "node scripts/verification/docker-run.js csharp",
         "verify:docker:rust": "node scripts/verification/docker-run.js rust",
         "verify:docker:java": "node scripts/verification/docker-run.js java",
+        "verify:docker:odata": "node scripts/verification/docker-run.js odata",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java', 'odata'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/test/verification/odata.validate.test.js
+++ b/test/verification/odata.validate.test.js
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const ODataVisitor = require('../../lib/codegen/fromcto/odata/odatavisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+/**
+ * Return a skip reason when xmllint is not available.
+ * @returns {string|null} skip reason or null when xmllint is available
+ */
+function getXmllintSkipReason() {
+    const version = spawnSync('xmllint', ['--version'], { encoding: 'utf-8' });
+    if (version.error || version.status !== 0) {
+        return 'xmllint (libxml2) not installed';
+    }
+    return null;
+}
+
+const XMLLINT_SKIP_REASON = getXmllintSkipReason();
+
+/**
+ * Generate OData CSDL and verify each .csdl is well-formed XML.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to ODataVisitor
+ */
+async function verifyODataWellFormed(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new ODataVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        const csdlFiles = fs.readdirSync(outputDir)
+            .filter((name) => name.endsWith('.csdl'))
+            .map((name) => path.join(outputDir, name));
+
+        if (csdlFiles.length === 0) {
+            throw new Error('ODataVisitor produced no .csdl files');
+        }
+
+        for (const csdl of csdlFiles) {
+            try {
+                execFileSync('xmllint', ['--noout', csdl], {
+                    encoding: 'utf-8',
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+            } catch (err) {
+                const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+                throw new Error(`${path.basename(csdl)}: ${details || err.message}`);
+            }
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(60000);
+
+    before(function () {
+        applyVerificationEnv();
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = XMLLINT_SKIP_REASON || getSkipReason(testCase, 'odata');
+        const title = skipReason
+            ? `generated OData CSDL from ${testCase.name} is well-formed XML (pending: ${skipReason})`
+            : `generated OData CSDL from ${testCase.name} is well-formed XML`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyODataWellFormed(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/verification/docker/base/Dockerfile
+++ b/verification/docker/base/Dockerfile
@@ -16,10 +16,14 @@ RUN npm install --no-save \
     @accordproject/concerto-vocabulary@^4.1.3
 
 # Point the global Concerto CLI at this checkout so PRs test branch codegen.
+# Also replace the copy nested under concerto-cli (Node resolves that first).
 RUN npm install -g @accordproject/concerto-cli \
     && GLOBAL_ROOT="$(npm root -g)" \
-    && rm -rf "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
-    && ln -s /opt/concerto-codegen "$GLOBAL_ROOT/@accordproject/concerto-codegen"
+    && find "$GLOBAL_ROOT" -type d -path '*/@accordproject/concerto-codegen' -print0 \
+        | xargs -0 -r rm -rf \
+    && ln -s /opt/concerto-codegen "$GLOBAL_ROOT/@accordproject/concerto-codegen" \
+    && mkdir -p "$GLOBAL_ROOT/@accordproject/concerto-cli/node_modules/@accordproject" \
+    && ln -s /opt/concerto-codegen "$GLOBAL_ROOT/@accordproject/concerto-cli/node_modules/@accordproject/concerto-codegen"
 
 ENV ENABLE_MAP_TYPE=true \
     IMPORT_ALIASING=true \

--- a/verification/docker/odata/Dockerfile
+++ b/verification/docker/odata/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+# Well-formed XML check for generated OData CSDL (.csdl).
+RUN apk add --no-cache libxml2-utils
+
+COPY verification/docker/odata/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/odata/entrypoint.sh
+++ b/verification/docker/odata/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Generate OData CSDL from the corpus and verify each .csdl is well-formed XML.
+set -eu
+
+CLI_TARGET=OData
+TARGET_KEY=odata
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    csdl_files=$(find "$out" -name '*.csdl' | sort)
+    if [ -z "$csdl_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with xmllint"
+    # shellcheck disable=SC2086
+    for csdl in $csdl_files; do
+        echo "    $csdl"
+        xmllint --noout "$csdl"
+    done
+done

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -40,5 +40,11 @@
         "baseImage": "eclipse-temurin:17-jdk-alpine",
         "tool": "javac",
         "type": "compiled"
+    },
+    "odata": {
+        "cli": "OData",
+        "baseImage": "node:20-alpine",
+        "tool": "xmllint --noout",
+        "type": "schema"
     }
 }


### PR DESCRIPTION
Adds OData to the Docker codegen verification pipeline, matching the existing GraphQL / JSON Schema schema targets.

### Changes
- Added `verification/docker/odata/` to generate `.csdl` via `concerto compile --target OData` and check well-formed XML with `xmllint --noout`
- Extended `verification/docker/targets.json`, `scripts/verification/docker-run.js`, `package.json` (`verify:docker:odata`), and the `verify-codegen` CI matrix
- Added `test/verification/odata.validate.test.js` for local well-formedness checks (skips if `xmllint` is not installed)
- Updated the verify base image so nested `concerto-cli` codegen resolves to this checkout

### Flags
- Validation is well-formed XML (`xmllint --noout`)
- Local mocha tests stay pending without `xmllint` (libxml2); Docker / CI is the authoritative check


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`

