### PR TITLE
feat(verification): add XML Schema, OpenAPI, and Avro Docker verification targets

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -31,6 +31,7 @@ jobs:
           - java
           - odata
           - mermaid
+          - xmlschema
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -32,6 +32,8 @@ jobs:
           - odata
           - mermaid
           - xmlschema
+          - openapi
+          - avro
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ output
 verification/work
 verification/work-*
 verification/templates/jackson-annotations-*.jar
+verification/templates/avro-tools-*.jar
 
 # Runtime data
 pids

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
             "devDependencies": {
                 "@accordproject/concerto-cto": "4.1.3",
                 "@babel/preset-env": "7.16.11",
+                "@redocly/cli": "1.34.3",
                 "@types/webgl-ext": "0.0.37",
                 "babel-loader": "8.2.3",
                 "chai": "4.3.6",
@@ -2079,6 +2080,23 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.1",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
@@ -2577,6 +2595,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@exodus/schemasafe": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+            "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@faker-js/faker": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+            "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=6.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -2588,6 +2624,16 @@
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.4"
             },
+            "engines": {
+                "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@humanwhocodes/momoa": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+            "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.10.0"
             }
@@ -3039,6 +3085,32 @@
                 "node": ">=v12.0.0"
             }
         },
+        "node_modules/@jsep-plugin/assignment": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+            "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.16.0"
+            },
+            "peerDependencies": {
+                "jsep": "^0.4.0||^1.0.0"
+            }
+        },
+        "node_modules/@jsep-plugin/regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+            "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.16.0"
+            },
+            "peerDependencies": {
+                "jsep": "^0.4.0||^1.0.0"
+            }
+        },
         "node_modules/@mermaid-js/parser": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
@@ -3048,6 +3120,19 @@
             "dependencies": {
                 "langium": "3.3.1"
             }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+            "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -3093,6 +3178,250 @@
                 "fast-deep-equal": "^3.1.3"
             }
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+            "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+            "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+            "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+            "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/otlp-exporter-base": "0.53.0",
+                "@opentelemetry/otlp-transformer": "0.53.0",
+                "@opentelemetry/resources": "1.26.0",
+                "@opentelemetry/sdk-trace-base": "1.26.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+            "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/otlp-transformer": "0.53.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+            "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.53.0",
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/resources": "1.26.0",
+                "@opentelemetry/sdk-logs": "0.53.0",
+                "@opentelemetry/sdk-metrics": "1.26.0",
+                "@opentelemetry/sdk-trace-base": "1.26.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+            "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+            "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+            "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+            "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.53.0",
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/resources": "1.26.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+            "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/resources": "1.26.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+            "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/resources": "1.26.0",
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+            "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.26.0",
+                "@opentelemetry/core": "1.26.0",
+                "@opentelemetry/propagator-b3": "1.26.0",
+                "@opentelemetry/propagator-jaeger": "1.26.0",
+                "@opentelemetry/sdk-trace-base": "1.26.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3116,6 +3445,72 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/@redocly/ajv": {
             "version": "8.11.2",
             "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
@@ -3131,6 +3526,142 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@redocly/cli": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.3.tgz",
+            "integrity": "sha512-GJNBTMfm5wTCtH6K+RtPQZuGbqflMclXqAZ5My12tfux6xFDMW1l0MNd5RMpnIS1aeFcDX++P1gnnROWlesj4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/api": "1.9.0",
+                "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+                "@opentelemetry/resources": "1.26.0",
+                "@opentelemetry/sdk-trace-node": "1.26.0",
+                "@opentelemetry/semantic-conventions": "1.27.0",
+                "@redocly/config": "^0.22.0",
+                "@redocly/openapi-core": "1.34.3",
+                "@redocly/respect-core": "1.34.3",
+                "abort-controller": "^3.0.0",
+                "chokidar": "^3.5.1",
+                "colorette": "^1.2.0",
+                "core-js": "^3.32.1",
+                "dotenv": "^16.4.7",
+                "form-data": "^4.0.0",
+                "get-port-please": "^3.0.1",
+                "glob": "^7.1.6",
+                "handlebars": "^4.7.6",
+                "mobx": "^6.0.4",
+                "pluralize": "^8.0.0",
+                "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.2.0 || ^19.0.0",
+                "redoc": "2.5.0",
+                "semver": "^7.5.2",
+                "simple-websocket": "^9.0.0",
+                "styled-components": "^6.0.7",
+                "yargs": "17.0.1"
+            },
+            "bin": {
+                "openapi": "bin/cli.js",
+                "redocly": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=18.17.0",
+                "npm": ">=9.5.0"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/@redocly/openapi-core": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.3.tgz",
+            "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@redocly/ajv": "^8.11.2",
+                "@redocly/config": "^0.22.0",
+                "colorette": "^1.2.0",
+                "https-proxy-agent": "^7.0.5",
+                "js-levenshtein": "^1.1.6",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^5.0.1",
+                "pluralize": "^8.0.0",
+                "yaml-ast-parser": "0.0.43"
+            },
+            "engines": {
+                "node": ">=18.17.0",
+                "npm": ">=9.5.0"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/brace-expansion": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/colorette": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@redocly/cli/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/yargs": {
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+            "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@redocly/cli/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@redocly/config": {
@@ -3190,6 +3721,211 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@redocly/respect-core": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.3.tgz",
+            "integrity": "sha512-vo/gu7dRGwTVsRueVSjVk04jOQuL0w22RBJRdRUWkfyse791tYXgMCOx35ijKekL83Q/7Okxf/YX6UY1v5CAug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@faker-js/faker": "^7.6.0",
+                "@redocly/ajv": "8.11.2",
+                "@redocly/openapi-core": "1.34.3",
+                "better-ajv-errors": "^1.2.0",
+                "colorette": "^2.0.20",
+                "concat-stream": "^2.0.0",
+                "cookie": "^0.7.2",
+                "dotenv": "16.4.5",
+                "form-data": "4.0.0",
+                "jest-diff": "^29.3.1",
+                "jest-matcher-utils": "^29.3.1",
+                "js-yaml": "4.1.0",
+                "json-pointer": "^0.6.2",
+                "jsonpath-plus": "^10.0.6",
+                "open": "^10.1.0",
+                "openapi-sampler": "^1.6.1",
+                "outdent": "^0.8.0",
+                "set-cookie-parser": "^2.3.5",
+                "undici": "^6.21.1"
+            },
+            "engines": {
+                "node": ">=18.17.0",
+                "npm": ">=9.5.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/@jest/schemas": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.3.tgz",
+            "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@redocly/ajv": "^8.11.2",
+                "@redocly/config": "^0.22.0",
+                "colorette": "^1.2.0",
+                "https-proxy-agent": "^7.0.5",
+                "js-levenshtein": "^1.1.6",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^5.0.1",
+                "pluralize": "^8.0.0",
+                "yaml-ast-parser": "0.0.43"
+            },
+            "engines": {
+                "node": ">=18.17.0",
+                "npm": ">=9.5.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core/node_modules/colorette": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@redocly/respect-core/node_modules/@sinclair/typebox": {
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@redocly/respect-core/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/brace-expansion": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/dotenv": {
+            "version": "16.4.5",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/jest-diff": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^29.6.3",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/jest-matcher-utils": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@redocly/respect-core/node_modules/pretty-format": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -3912,6 +4648,19 @@
             "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
             "dev": true
         },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4058,6 +4807,19 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/append-transform": {
             "version": "2.0.0",
@@ -4318,6 +5080,26 @@
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
+        "node_modules/better-ajv-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
+            "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/code-frame": "^7.16.0",
+                "@humanwhocodes/momoa": "^2.0.2",
+                "chalk": "^4.1.2",
+                "jsonpointer": "^5.0.0",
+                "leven": "^3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "peerDependencies": {
+                "ajv": "4.11.8 - 8"
+            }
+        },
         "node_modules/big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -4325,6 +5107,19 @@
             "dev": true,
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/bluebird": {
@@ -4609,6 +5404,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/caching-transform": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -4686,6 +5497,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-me-maybe": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+            "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4704,6 +5522,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/caniuse-lite": {
@@ -4845,6 +5673,44 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -4885,6 +5751,13 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/classnames": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4918,6 +5791,16 @@
                 "kind-of": "^6.0.2",
                 "shallow-clone": "^3.0.0"
             },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -4989,6 +5872,22 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
+        "node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "dev": true,
+            "engines": [
+                "node >= 6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
         "node_modules/console-browserify": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -5007,6 +5906,28 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
         },
         "node_modules/core-js-compat": {
             "version": "3.39.0",
@@ -5141,6 +6062,7 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -5177,6 +6099,28 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/css-to-react-native": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
+        },
         "node_modules/cssstyle": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -5195,6 +6139,13 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5802,6 +6753,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/decko": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+            "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
+            "dev": true
+        },
         "node_modules/deep-eql": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -5819,6 +6776,36 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/default-require-extensions": {
             "version": "3.0.1",
@@ -5851,6 +6838,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/define-properties": {
@@ -5912,6 +6912,16 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/diffie-hellman": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -5964,6 +6974,19 @@
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/drange": {
@@ -6170,6 +7193,13 @@
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
             "dev": true
+        },
+        "node_modules/es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.27.1",
@@ -6463,6 +7493,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6569,6 +7616,13 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -6584,6 +7638,47 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+            "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.6.2",
+                "xml-naming": "^0.3.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+            "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^3.0.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^2.0.0",
+                "path-expression-matcher": "^1.6.2",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.3.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -6737,6 +7832,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/foreach": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+            "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/foreground-child": {
             "version": "2.0.0",
@@ -6894,6 +7996,13 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/get-port-please": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+            "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/get-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7027,6 +8136,28 @@
             "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -7192,6 +8323,13 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/http2-client": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+            "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/https-browserify": {
             "version": "1.0.0",
@@ -7402,6 +8540,19 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -7428,6 +8579,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-extglob": {
@@ -7478,6 +8645,25 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-nan": {
@@ -7599,6 +8785,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+            "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -7612,6 +8811,22 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -7794,6 +9009,16 @@
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-get-type": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-haste-map": {
@@ -8110,6 +9335,16 @@
                 }
             }
         },
+        "node_modules/jsep": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+            "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.16.0"
+            }
+        },
         "node_modules/jsesc": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -8133,6 +9368,16 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
+        },
+        "node_modules/json-pointer": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+            "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "foreach": "^2.0.4"
+            }
         },
         "node_modules/json-schema-migrate": {
             "version": "2.0.0",
@@ -8177,6 +9422,35 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jsonpath-plus": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+            "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jsep-plugin/assignment": "^1.3.0",
+                "@jsep-plugin/regex": "^1.0.4",
+                "jsep": "^1.4.0"
+            },
+            "bin": {
+                "jsonpath": "bin/jsonpath-cli.js",
+                "jsonpath-plus": "bin/jsonpath-cli.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/jsonpointer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/just-extend": {
@@ -8268,6 +9542,16 @@
             "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/levn": {
             "version": "0.4.1",
@@ -8479,6 +9763,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
         "node_modules/lorem-ipsum": {
             "version": "2.0.8",
             "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
@@ -8513,6 +9817,13 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8546,6 +9857,13 @@
             "dependencies": {
                 "tmpl": "1.0.5"
             }
+        },
+        "node_modules/mark.js": {
+            "version": "8.11.1",
+            "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+            "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/markdown-it": {
             "version": "14.1.1",
@@ -8812,6 +10130,69 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/mobx": {
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.16.1.tgz",
+            "integrity": "sha512-syNcDdX3KT+Jq3je6eGjBhuc24Z68td2VG0zNFqRswaE433D9SNH5VRy/xrGbJsUixfppLLccXhAW9JSf6n+SQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mobx"
+            }
+        },
+        "node_modules/mobx-react": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.2.tgz",
+            "integrity": "sha512-ShszmQzR/VrhU3M0cQ7DA/s8qNcLcF2emSuudJ/TnDILS3C1Im48mdaG6CpyjZHy8+WqgXUCC9mPqSRIwPPMuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mobx-react-lite": "^4.1.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mobx"
+            },
+            "peerDependencies": {
+                "mobx": "^6.9.0",
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mobx-react-lite": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+            "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "use-sync-external-store": "^1.4.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mobx"
+            },
+            "peerDependencies": {
+                "mobx": "^6.9.0",
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
             }
         },
         "node_modules/mocha": {
@@ -9100,6 +10481,65 @@
                 "node": ">=4"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch-h2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+            "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "http2-client": "^1.2.5"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9134,6 +10574,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/node-readfiles": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+            "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es6-promise": "^3.2.1"
             }
         },
         "node_modules/node-releases": {
@@ -9471,6 +10921,111 @@
                 "node": ">=6"
             }
         },
+        "node_modules/oas-kit-common": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+            "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "node_modules/oas-linter": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+            "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@exodus/schemasafe": "^1.0.0-rc.2",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-linter/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/oas-resolver": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+            "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "node-fetch-h2": "^2.3.0",
+                "oas-kit-common": "^1.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "resolve": "resolve.js"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-resolver/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/oas-schema-walker": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+            "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-validator": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+            "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "call-me-maybe": "^1.0.1",
+                "oas-kit-common": "^1.0.8",
+                "oas-linter": "^3.2.2",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "reftools": "^1.1.9",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-validator/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9574,6 +11129,37 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/openapi-sampler": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.4.tgz",
+            "integrity": "sha512-CKS/rd5ucPCuEDbJnjGDXZTsuGWcmv53aCmQx7soZlPEONUGN4af0/dY5+THRFZraSEjeA78nlfzdFswC/N5SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.7",
+                "fast-xml-parser": "^5.5.1",
+                "json-pointer": "0.6.2"
+            }
+        },
         "node_modules/openapi-typescript": {
             "version": "7.13.0",
             "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -9647,6 +11233,13 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/outdent": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+            "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
             "dev": true,
             "license": "MIT"
         },
@@ -9825,6 +11418,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9903,6 +11512,13 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/perfect-scrollbar": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+            "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -10093,6 +11709,19 @@
                 "points-on-curve": "0.2.0"
             }
         },
+        "node_modules/polished": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+            "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.17.8"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10102,6 +11731,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
@@ -10140,6 +11776,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -10176,6 +11822,49 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/prop-types/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/protobufjs": {
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
+                "@types/node": ">=13.7.0",
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/proxy-from-env": {
@@ -10308,12 +11997,49 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "node_modules/react": {
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.7"
+            }
+        },
         "node_modules/react-is": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/react-tabs": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.1.tgz",
+            "integrity": "sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clsx": "^2.0.0",
+                "prop-types": "^15.5.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0"
+            }
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -10330,6 +12056,19 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/rechoir": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -10340,6 +12079,57 @@
             },
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/redoc": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.0.tgz",
+            "integrity": "sha512-NpYsOZ1PD9qFdjbLVBZJWptqE+4Y6TkUuvEOqPUmoH7AKOmPcE+hYjotLxQNTqVoWL4z0T2uxILmcc8JGDci+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@redocly/openapi-core": "^1.4.0",
+                "classnames": "^2.3.2",
+                "decko": "^1.2.0",
+                "dompurify": "^3.2.4",
+                "eventemitter3": "^5.0.1",
+                "json-pointer": "^0.6.2",
+                "lunr": "^2.3.9",
+                "mark.js": "^8.11.1",
+                "marked": "^4.3.0",
+                "mobx-react": "^9.1.1",
+                "openapi-sampler": "^1.5.0",
+                "path-browserify": "^1.0.1",
+                "perfect-scrollbar": "^1.5.5",
+                "polished": "^4.2.2",
+                "prismjs": "^1.29.0",
+                "prop-types": "^15.8.1",
+                "react-tabs": "^6.0.2",
+                "slugify": "~1.4.7",
+                "stickyfill": "^1.1.1",
+                "swagger2openapi": "^7.0.8",
+                "url-template": "^2.0.8"
+            },
+            "engines": {
+                "node": ">=6.9",
+                "npm": ">=3.0.0"
+            },
+            "peerDependencies": {
+                "core-js": "^3.1.4",
+                "mobx": "^6.0.4",
+                "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+            }
+        },
+        "node_modules/reftools": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+            "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
         },
         "node_modules/regenerate": {
@@ -10661,6 +12451,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10758,6 +12561,13 @@
                 "node": ">=v12.22.7"
             }
         },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/schema-utils": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -10835,6 +12645,13 @@
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
             "dev": true
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -10914,6 +12731,66 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/should": {
+            "version": "13.2.3",
+            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
+            }
+        },
+        "node_modules/should-equal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "should-type": "^1.4.0"
+            }
+        },
+        "node_modules/should-format": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+            "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
+            }
+        },
+        "node_modules/should-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+            "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/should-type-adaptors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
+            }
+        },
+        "node_modules/should-util": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/side-channel": {
             "version": "1.1.1",
@@ -10997,6 +12874,56 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
+        "node_modules/simple-websocket": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+            "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.1",
+                "queue-microtask": "^1.2.2",
+                "randombytes": "^2.1.0",
+                "readable-stream": "^3.6.0",
+                "ws": "^7.4.2"
+            }
+        },
+        "node_modules/simple-websocket/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/sinon": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.0.tgz",
@@ -11032,6 +12959,16 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/slugify": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+            "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/source-map": {
@@ -11099,6 +13036,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/stickyfill": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+            "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==",
+            "dev": true
         },
         "node_modules/stream-browserify": {
             "version": "3.0.0",
@@ -11218,6 +13161,66 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
+        },
+        "node_modules/styled-components": {
+            "version": "6.4.4",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.4.tgz",
+            "integrity": "sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/is-prop-valid": "1.4.0",
+                "css-to-react-native": "3.2.0",
+                "csstype": "3.2.3",
+                "stylis": "4.3.6"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/styled-components"
+            },
+            "peerDependencies": {
+                "css-to-react-native": ">= 3.2.0",
+                "react": ">= 16.8.0",
+                "react-dom": ">= 16.8.0",
+                "react-native": ">= 0.68.0"
+            },
+            "peerDependenciesMeta": {
+                "css-to-react-native": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/styled-components/node_modules/stylis": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+            "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stylis": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
@@ -11247,6 +13250,44 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/swagger2openapi": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+            "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "call-me-maybe": "^1.0.1",
+                "node-fetch": "^2.6.1",
+                "node-fetch-h2": "^2.3.0",
+                "node-readfiles": "^0.2.0",
+                "oas-kit-common": "^1.0.8",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "oas-validator": "^5.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "boast": "boast.js",
+                "oas-validate": "oas-validate.js",
+                "swagger2openapi": "swagger2openapi.js"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/swagger2openapi/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/symbol": {
@@ -11924,6 +13965,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/typedarray-to-buffer": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -11952,12 +14000,36 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true
         },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/underscore": {
             "version": "1.13.8",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/undici": {
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",
@@ -12066,12 +14138,29 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/url-template": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+            "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+            "dev": true,
+            "license": "BSD"
+        },
         "node_modules/url/node_modules/punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
         },
         "node_modules/util": {
             "version": "0.12.5",
@@ -12504,6 +14593,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/workerpool": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -12601,6 +14697,22 @@
                 }
             }
         },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -12609,6 +14721,22 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "verify:docker:java": "node scripts/verification/docker-run.js java",
         "verify:docker:odata": "node scripts/verification/docker-run.js odata",
         "verify:docker:mermaid": "node scripts/verification/docker-run.js mermaid",
+        "verify:docker:xmlschema": "node scripts/verification/docker-run.js xmlschema",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
         "verify:docker:odata": "node scripts/verification/docker-run.js odata",
         "verify:docker:mermaid": "node scripts/verification/docker-run.js mermaid",
         "verify:docker:xmlschema": "node scripts/verification/docker-run.js xmlschema",
+        "verify:docker:openapi": "node scripts/verification/docker-run.js openapi",
+        "verify:docker:avro": "node scripts/verification/docker-run.js avro",
         "test:updateSnapshots": "nyc mocha --updateSnapshot --recursive -t 10000",
         "test:watch": "nyc mocha --watch --recursive -t 10000",
         "mocha": "mocha --recursive -t 10000",
@@ -62,6 +64,7 @@
     "devDependencies": {
         "@accordproject/concerto-cto": "4.1.3",
         "@babel/preset-env": "7.16.11",
+        "@redocly/cli": "1.34.3",
         "@types/webgl-ext": "0.0.37",
         "babel-loader": "8.2.3",
         "chai": "4.3.6",

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java', 'odata', 'mermaid', 'xmlschema'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java', 'odata', 'mermaid', 'xmlschema', 'openapi', 'avro'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/scripts/verification/docker-run.js
+++ b/scripts/verification/docker-run.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 const ROOT = path.join(__dirname, '../..');
 const BASE_IMAGE = 'concerto-verify-base:local';
-const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java', 'odata', 'mermaid'];
+const TARGETS = ['typescript', 'jsonschema', 'graphql', 'protobuf', 'csharp', 'rust', 'java', 'odata', 'mermaid', 'xmlschema'];
 
 /**
  * Run a command synchronously with inherited stdio.

--- a/test/verification/avro.validate.test.js
+++ b/test/verification/avro.validate.test.js
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const https = require('https');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const AvroVisitor = require('../../lib/codegen/fromcto/avro/avrovisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+const AVRO_TOOLS_VERSION = '1.12.0';
+const AVRO_TOOLS_JAR = process.env.AVRO_TOOLS_JAR || path.join(
+    __dirname,
+    '../../verification/templates',
+    `avro-tools-${AVRO_TOOLS_VERSION}.jar`
+);
+const AVRO_TOOLS_URL = `https://repo1.maven.org/maven2/org/apache/avro/avro-tools/${AVRO_TOOLS_VERSION}/avro-tools-${AVRO_TOOLS_VERSION}.jar`;
+
+/**
+ * Download the Apache avro-tools JAR used to compile generated Avro IDL.
+ * @returns {Promise<void>} resolves when the JAR has been written to disk
+ */
+function downloadAvroToolsJar() {
+    return new Promise((resolve, reject) => {
+        fs.mkdirSync(path.dirname(AVRO_TOOLS_JAR), { recursive: true });
+        const file = fs.createWriteStream(AVRO_TOOLS_JAR);
+        https.get(AVRO_TOOLS_URL, (response) => {
+            if (response.statusCode !== 200) {
+                reject(new Error(`Failed to download avro-tools (${response.statusCode})`));
+                return;
+            }
+            response.pipe(file);
+            file.on('finish', () => {
+                file.close(resolve);
+            });
+        }).on('error', reject);
+    });
+}
+
+/**
+ * Return the path to the avro-tools JAR, downloading it if needed.
+ * @returns {Promise<string>} absolute path to the JAR
+ */
+async function ensureAvroToolsJar() {
+    if (!fs.existsSync(AVRO_TOOLS_JAR)) {
+        await downloadAvroToolsJar();
+    }
+    return AVRO_TOOLS_JAR;
+}
+
+/**
+ * Return a skip reason when java is not available.
+ * @returns {string|null} skip reason or null when java is available
+ */
+function getJavaSkipReason() {
+    const version = spawnSync('java', ['-version'], { encoding: 'utf-8' });
+    if (version.error || version.status !== 0) {
+        return 'java (JRE) not installed';
+    }
+    return null;
+}
+
+const JAVA_SKIP_REASON = getJavaSkipReason();
+let avroToolsJar;
+
+/**
+ * Generate Avro IDL from a model and verify each .avdl compiles with avro-tools idl.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to AvroVisitor
+ */
+async function verifyAvroIdlCompiles(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new AvroVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        const avdlFiles = fs.readdirSync(outputDir)
+            .filter((name) => name.endsWith('.avdl'))
+            .map((name) => path.join(outputDir, name));
+
+        if (avdlFiles.length === 0) {
+            throw new Error('AvroVisitor produced no .avdl files');
+        }
+
+        for (const avdl of avdlFiles) {
+            try {
+                execFileSync('java', ['-jar', avroToolsJar, 'idl', avdl], {
+                    encoding: 'utf-8',
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+            } catch (err) {
+                const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+                throw new Error(`${path.basename(avdl)}: ${details || err.message}`);
+            }
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(120000);
+
+    before(async function () {
+        applyVerificationEnv();
+        if (JAVA_SKIP_REASON) {
+            // eslint-disable-next-line no-console
+            console.warn(`Skipping Avro verification tests: ${JAVA_SKIP_REASON}`);
+            return;
+        }
+        avroToolsJar = await ensureAvroToolsJar();
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = getSkipReason(testCase, 'avro') || JAVA_SKIP_REASON;
+        const title = skipReason
+            ? `generated Avro IDL from ${testCase.name} compiles with avro-tools idl (pending: ${skipReason})`
+            : `generated Avro IDL from ${testCase.name} compiles with avro-tools idl`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyAvroIdlCompiles(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/test/verification/cases.js
+++ b/test/verification/cases.js
@@ -26,7 +26,7 @@ const MODEL_DIR = path.join(__dirname, '../codegen/fromcto/data/model');
  * Each case loads one fixture (or valid combination) into its own ModelManager.
  * Do not combine unrelated CTO files — some share namespaces or have import deps.
  *
- * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...', java: '...' }`.
+ * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...', java: '...', xmlschema: '...' }`.
  */
 const CASES = [
     {

--- a/test/verification/cases.js
+++ b/test/verification/cases.js
@@ -26,7 +26,7 @@ const MODEL_DIR = path.join(__dirname, '../codegen/fromcto/data/model');
  * Each case loads one fixture (or valid combination) into its own ModelManager.
  * Do not combine unrelated CTO files — some share namespaces or have import deps.
  *
- * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...', java: '...', xmlschema: '...' }`.
+ * `skip` may be a string (all targets) or `{ typescript: '...', jsonschema: '...', protobuf: '...', graphql: '...', csharp: '...', rust: '...', java: '...', xmlschema: '...', openapi: '...', avro: '...' }`.
  */
 const CASES = [
     {
@@ -34,6 +34,9 @@ const CASES = [
         setup(modelManager) {
             // Same as `concerto compile --target <format> --metamodel` in concerto-cli
             modelManager.addCTOModel(MetaModelUtil.metaModelCto);
+        },
+        skip: {
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
         },
     },
     {
@@ -44,6 +47,7 @@ const CASES = [
             protobuf:'Empty enum produces invalid Protobuf (enum must have >= 1 item)',
             graphql: 'map types emit invalid GraphQL SDL (key/value field syntax)',
             rust: 'map declarations reference scalar key/value types (e.g. SSN) that the Rust visitor does not emit, so cargo check fails',
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
         },
     },
     {
@@ -57,23 +61,39 @@ const CASES = [
             graphql: 'map types emit invalid GraphQL SDL (key/value field syntax)',
             rust: 'map declarations reference scalar key/value types (e.g. SSN, Time) that the Rust visitor does not emit, so cargo check fails',
             java: 'map declarations reference scalar key/value types (e.g. SSN, Time) that the Java visitor does not emit, so javac fails',
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
+            openapi: 'JSON Schema $decorators and invalid schema nesting fail OpenAPI struct validation',
         },
     },
     {
         name: 'stringlength',
         files: ['stringlength.cto'],
+        skip: {
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
+        },
     },
     {
         name: 'model-base',
         files: ['model-base.cto'],
+        skip: {
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
+            openapi: 'JSON Schema $decorators fail OpenAPI struct validation',
+        },
     },
     {
         name: 'agreement',
         files: ['agreement.cto'],
+        skip: {
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
+            openapi: 'JSON Schema $decorators fail OpenAPI struct validation',
+        },
     },
     {
         name: 'circular',
         files: ['circular.cto'],
+        skip: {
+            avro: 'versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment "0")',
+        },
     },
 ];
 

--- a/test/verification/openapi.validate.test.js
+++ b/test/verification/openapi.validate.test.js
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const OpenApiVisitor = require('../../lib/codegen/fromcto/openapi/openapivisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+const REDOCLY_CONFIG_PATH = process.env.REDOCLY_CONFIG
+    || path.join(__dirname, '../../verification/docker/openapi/redocly.yaml');
+const REDOCLY_CLI = require.resolve('@redocly/cli/bin/cli.js');
+
+/**
+ * Generate OpenAPI from a model and verify it lints clean with redocly.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to OpenApiVisitor
+ */
+async function verifyOpenApiLints(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+
+    try {
+        modelManager.accept(new OpenApiVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        const jsonFiles = fs.readdirSync(outputDir)
+            .filter((name) => name.endsWith('.json'))
+            .map((name) => path.join(outputDir, name));
+
+        if (jsonFiles.length === 0) {
+            throw new Error('OpenApiVisitor produced no .json files');
+        }
+
+        for (const json of jsonFiles) {
+            try {
+                execFileSync(process.execPath, [
+                    REDOCLY_CLI,
+                    'lint',
+                    json,
+                    '--config',
+                    REDOCLY_CONFIG_PATH,
+                    '--format',
+                    'stylish',
+                ], {
+                    encoding: 'utf-8',
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+            } catch (err) {
+                const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+                throw new Error(`${path.basename(json)}: ${details || err.message}`);
+            }
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(60000);
+
+    before(function () {
+        applyVerificationEnv();
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = getSkipReason(testCase, 'openapi');
+        const title = skipReason
+            ? `generated OpenAPI from ${testCase.name} lints clean with redocly (pending: ${skipReason})`
+            : `generated OpenAPI from ${testCase.name} lints clean with redocly`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyOpenApiLints(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/test/verification/openapi.validate.test.js
+++ b/test/verification/openapi.validate.test.js
@@ -29,8 +29,7 @@ const {
     applyVerificationEnv,
 } = require('./cases.js');
 
-const REDOCLY_CONFIG_PATH = process.env.REDOCLY_CONFIG
-    || path.join(__dirname, '../../verification/docker/openapi/redocly.yaml');
+const REDOCLY_CONFIG_PATH = process.env.REDOCLY_CONFIG || path.join(__dirname, '../../verification/docker/openapi/redocly.yaml');
 const REDOCLY_CLI = require.resolve('@redocly/cli/bin/cli.js');
 
 /**

--- a/test/verification/xmlschema.validate.test.js
+++ b/test/verification/xmlschema.validate.test.js
@@ -29,8 +29,7 @@ const {
     applyVerificationEnv,
 } = require('./cases.js');
 
-const XSD_META_SCHEMA_PATH = process.env.XMLSCHEMA_META_SCHEMA
-    || '/usr/local/share/XMLSchema.xsd';
+const XSD_META_SCHEMA_PATH = process.env.XMLSCHEMA_META_SCHEMA || '/usr/local/share/XMLSchema.xsd';
 const XSD_META_SCHEMA_URL = 'http://www.w3.org/2001/XMLSchema.xsd';
 
 /**

--- a/test/verification/xmlschema.validate.test.js
+++ b/test/verification/xmlschema.validate.test.js
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { dir } = require('tmp-promise');
+
+const { FileWriter } = require('@accordproject/concerto-util');
+const XmlSchemaVisitor = require('../../lib/codegen/fromcto/xmlschema/xmlschemavisitor.js');
+
+const {
+    CASES,
+    getSkipReason,
+    createModelManager,
+    applyVerificationEnv,
+} = require('./cases.js');
+
+const XSD_META_SCHEMA_PATH = process.env.XMLSCHEMA_META_SCHEMA
+    || '/usr/local/share/XMLSchema.xsd';
+const XSD_META_SCHEMA_URL = 'http://www.w3.org/2001/XMLSchema.xsd';
+
+/**
+ * Return a skip reason when xmllint is not available.
+ * @returns {string|null} skip reason or null when xmllint is available
+ */
+function getXmllintSkipReason() {
+    const version = spawnSync('xmllint', ['--version'], { encoding: 'utf-8' });
+    if (version.error || version.status !== 0) {
+        return 'xmllint (libxml2) not installed';
+    }
+    return null;
+}
+
+const XMLLINT_SKIP_REASON = getXmllintSkipReason();
+
+/**
+ * Resolve the W3C XML Schema for Schemas used by xmllint --schema.
+ * @returns {string} path or URL to the meta-schema
+ */
+function resolveXsdMetaSchema() {
+    if (fs.existsSync(XSD_META_SCHEMA_PATH)) {
+        return XSD_META_SCHEMA_PATH;
+    }
+    return XSD_META_SCHEMA_URL;
+}
+
+/**
+ * Generate XML Schema from a model and verify each .xsd with xmllint --schema.
+ * @param {ModelManager} modelManager populated model manager
+ * @param {object} [visitorOptions] options passed to XmlSchemaVisitor
+ */
+async function verifyXmlSchemaValid(modelManager, visitorOptions = {}) {
+    const { path: outputDir, cleanup } = await dir({ unsafeCleanup: true });
+    const metaSchema = resolveXsdMetaSchema();
+
+    try {
+        modelManager.accept(new XmlSchemaVisitor(), {
+            fileWriter: new FileWriter(outputDir),
+            ...visitorOptions,
+        });
+
+        const xsdFiles = fs.readdirSync(outputDir)
+            .filter((name) => name.endsWith('.xsd'))
+            .map((name) => path.join(outputDir, name));
+
+        if (xsdFiles.length === 0) {
+            throw new Error('XmlSchemaVisitor produced no .xsd files');
+        }
+
+        for (const xsd of xsdFiles) {
+            try {
+                execFileSync('xmllint', ['--noout', '--schema', metaSchema, xsd], {
+                    encoding: 'utf-8',
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+            } catch (err) {
+                const details = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+                throw new Error(`${path.basename(xsd)}: ${details || err.message}`);
+            }
+        }
+    } finally {
+        await cleanup();
+    }
+}
+
+describe('verification', function () {
+    this.timeout(60000);
+
+    before(function () {
+        applyVerificationEnv();
+    });
+
+    CASES.forEach(function (testCase) {
+        const skipReason = XMLLINT_SKIP_REASON || getSkipReason(testCase, 'xmlschema');
+        const title = skipReason
+            ? `generated XML Schema from ${testCase.name} validates with xmllint --schema (pending: ${skipReason})`
+            : `generated XML Schema from ${testCase.name} validates with xmllint --schema`;
+        const run = skipReason ? it.skip : it;
+
+        run(title, async function () {
+            const modelManager = createModelManager(testCase);
+            await verifyXmlSchemaValid(modelManager, testCase.visitorOptions || {});
+        });
+    });
+});

--- a/verification/corpus/manifest.json
+++ b/verification/corpus/manifest.json
@@ -11,7 +11,8 @@
                 "offline": true
             },
             "skip": {
-                "csharp": "generated C# references AccordProject.Concerto runtime types (e.g. ConcertoConverterFactorySystem) that are not available for a standalone dotnet build"
+                "csharp": "generated C# references AccordProject.Concerto runtime types (e.g. ConcertoConverterFactorySystem) that are not available for a standalone dotnet build",
+                "avro": "versioned namespaces (e.g. concerto.decorator@1.0.0) are illegal Avro identifiers (segment \"0\")"
             }
         }
     ]

--- a/verification/docker/avro/Dockerfile
+++ b/verification/docker/avro/Dockerfile
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+# Avro IDL validation via the official Apache avro-tools jar (idl -> Avro Protocol).
+RUN apk add --no-cache openjdk17-jre-headless curl \
+    && curl -fsSL -o /usr/local/share/avro-tools.jar \
+        https://archive.apache.org/dist/avro/avro-1.12.0/java/avro-tools-1.12.0.jar
+
+COPY verification/docker/avro/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/avro/entrypoint.sh
+++ b/verification/docker/avro/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generate Avro IDL from the corpus and verify each .avdl compiles with avro-tools idl.
+set -eu
+
+CLI_TARGET=Avro
+TARGET_KEY=avro
+AVRO_TOOLS_JAR=/usr/local/share/avro-tools.jar
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    avdl_files=$(find "$out" -name '*.avdl' | sort)
+    if [ -z "$avdl_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with avro-tools idl"
+    # shellcheck disable=SC2086
+    for avdl in $avdl_files; do
+        echo "    $avdl"
+        java -jar "$AVRO_TOOLS_JAR" idl "$avdl" > /dev/null
+    done
+done

--- a/verification/docker/openapi/Dockerfile
+++ b/verification/docker/openapi/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+# OpenAPI validation: redocly lint against the generated openapi.json.
+RUN npm install -g @redocly/cli@1.34.3
+
+COPY verification/docker/openapi/redocly.yaml /etc/redocly.yaml
+COPY verification/docker/openapi/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/openapi/entrypoint.sh
+++ b/verification/docker/openapi/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generate OpenAPI from the corpus and verify each openapi.json lints clean with redocly.
+set -eu
+
+CLI_TARGET=OpenApi
+TARGET_KEY=openapi
+REDOCLY_CONFIG=/etc/redocly.yaml
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    json_files=$(find "$out" -name '*.json' | sort)
+    if [ -z "$json_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with redocly lint"
+    # shellcheck disable=SC2086
+    for json in $json_files; do
+        echo "    $json"
+        redocly lint "$json" --config "$REDOCLY_CONFIG" --format stylish
+    done
+done

--- a/verification/docker/openapi/redocly.yaml
+++ b/verification/docker/openapi/redocly.yaml
@@ -1,0 +1,2 @@
+extends:
+  - minimal

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -52,5 +52,11 @@
         "baseImage": "node:20-alpine",
         "tool": "mermaid.parse",
         "type": "schema"
+    },
+    "xmlschema": {
+        "cli": "XMLSchema",
+        "baseImage": "node:20-alpine",
+        "tool": "xmllint --schema",
+        "type": "schema"
     }
 }

--- a/verification/docker/targets.json
+++ b/verification/docker/targets.json
@@ -58,5 +58,17 @@
         "baseImage": "node:20-alpine",
         "tool": "xmllint --schema",
         "type": "schema"
+    },
+    "openapi": {
+        "cli": "OpenApi",
+        "baseImage": "node:20-alpine",
+        "tool": "redocly lint",
+        "type": "schema"
+    },
+    "avro": {
+        "cli": "Avro",
+        "baseImage": "node:20-alpine",
+        "tool": "avro-tools idl",
+        "type": "schema"
     }
 }

--- a/verification/docker/xmlschema/Dockerfile
+++ b/verification/docker/xmlschema/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=concerto-verify-base:local
+FROM ${BASE_IMAGE}
+
+# XML Schema validation: xmllint --schema against the W3C XML Schema for Schemas.
+RUN apk add --no-cache libxml2-utils curl \
+    && curl -fsSL -o /usr/local/share/XMLSchema.xsd http://www.w3.org/2001/XMLSchema.xsd
+
+COPY verification/docker/xmlschema/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/verification/docker/xmlschema/entrypoint.sh
+++ b/verification/docker/xmlschema/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generate XML Schema from the corpus and verify each .xsd with xmllint --schema.
+set -eu
+
+CLI_TARGET=XMLSchema
+TARGET_KEY=xmlschema
+XSD_META_SCHEMA=/usr/local/share/XMLSchema.xsd
+
+for case_name in $(jq -r '.cases[].name' "${CORPUS_DIR}/manifest.json"); do
+    out="${WORK_DIR}/${case_name}"
+    mkdir -p "$out"
+
+    run-case.sh "$case_name" "$CLI_TARGET" "$TARGET_KEY" "$out"
+
+    xsd_files=$(find "$out" -name '*.xsd' | sort)
+    if [ -z "$xsd_files" ]; then
+        continue
+    fi
+
+    echo "==> VERIFY $case_name with xmllint --schema"
+    # shellcheck disable=SC2086
+    for xsd in $xsd_files; do
+        echo "    $xsd"
+        xmllint --noout --schema "$XSD_META_SCHEMA" "$xsd"
+    done
+done


### PR DESCRIPTION

This PR extends the Docker based codegen verification harness with three new schema targets: XML Schema, OpenAPI, and Avro. Each target gets a Docker image, an entrypoint that generates from the corpus and runs an external validator, a local Mocha verification test, registration in `verification/docker/targets.json` and `scripts/verification/docker-run.js`, a `verify:docker:<target>` npm script, and a matrix entry in `.github/workflows/verify-codegen.yml`.

Where generated output is known to be rejected by the external tool because of existing visitor limitations, the affected case and target pairs are skipped with an explicit reason (same pattern as protobuf, graphql, rust, and java).

### Changes

#### Shared wiring
- Registered `xmlschema`, `openapi`, and `avro` in `verification/docker/targets.json`.
- Extended `scripts/verification/docker-run.js` `TARGETS` to include all three.
- Added npm scripts: `verify:docker:xmlschema`, `verify:docker:openapi`, `verify:docker:avro`.
- Added all three targets to the `verify-codegen` GitHub Actions matrix.
- Extended per target skip documentation in `test/verification/cases.js` and, for the Docker corpus metamodel case, in `verification/corpus/manifest.json`.

#### XML Schema (`xmlschema`)
- Added `verification/docker/xmlschema/Dockerfile` and `entrypoint.sh`.
- Image installs `libxml2-utils` and downloads the W3C XML Schema for Schemas (`XMLSchema.xsd`) at build time.
- Entrypoint generates CTO to `.xsd` via CLI target `XMLSchema`, then validates each file with `xmllint --noout --schema` against the bundled meta schema.
- Added `test/verification/xmlschema.validate.test.js`: generates with `XmlSchemaVisitor`, validates with `xmllint --schema`. Locally skips the suite when `xmllint` is not installed. Falls back to the W3C URL if the local meta schema path is missing (override with `XMLSCHEMA_META_SCHEMA`).

#### OpenAPI (`openapi`)
- Added `verification/docker/openapi/Dockerfile`, `entrypoint.sh`, and `redocly.yaml` (`extends: minimal`).
- Image installs `@redocly/cli@1.34.3` globally. Entrypoint generates via CLI target `OpenApi`, then runs `redocly lint` on each `openapi.json`.
- Added `test/verification/openapi.validate.test.js`: generates with `OpenApiVisitor`, lints with the local `@redocly/cli` package (devDependency) via `require.resolve` and `node`, so no global CLI install is required on developer machines.
- Uses the same `verification/docker/openapi/redocly.yaml` config locally (override with `REDOCLY_CONFIG`).

#### Avro (`avro`)
- Added `verification/docker/avro/Dockerfile` and `entrypoint.sh`.
- Image installs a JRE and downloads Apache `avro-tools-1.12.0.jar`. Entrypoint generates via CLI target `Avro`, then runs `java -jar … idl` on each `.avdl`.
- Added `test/verification/avro.validate.test.js`: mirrors the Java Jackson jar pattern. Downloads `avro-tools-1.12.0.jar` from Maven Central into `verification/templates/` on first run when missing (override with `AVRO_TOOLS_JAR`). Only skips when Java is not installed.
- Gitignored `verification/templates/avro-tools-*.jar` (same approach as `jackson-annotations-*.jar`).

### Skips (what and why)

These skips document known visitor output issues. They are not Docker or harness bugs. Fixing them belongs in follow up visitor PRs (plus snapshot updates).

#### Avro: illegal versioned namespaces

`AvroVisitor` emits `@namespace("concerto.decorator@1.0.0")` (and similar). Avro IDL rejects that namespace because version segments such as `0` are illegal identifiers (`SchemaParseException: Illegal name: 0`).

| Case | Target | Why skipped |
|------|--------|-------------|
| `metamodel` | `avro` | Generates versioned system namespaces including `concerto.decorator@1.0.0` |
| `hr_base` | `avro` | Same versioned namespace problem when decorator or system models are present |
| `hr_integration` | `avro` | Same |
| `stringlength` | `avro` | Same |
| `model-base` | `avro` | Same |
| `agreement` | `avro` | Same |
| `circular` | `avro` | Same |

Docker corpus: metamodel case also skips `avro` for the same reason in `verification/corpus/manifest.json`.

#### OpenAPI: `$decorators` and invalid schema nesting

`OpenApiVisitor` embeds JSON Schema from `JSONSchemaVisitor`. That payload includes `$decorators` (and in some graphs invalid `schema` nesting) which Redocly's OpenAPI struct rules reject. Component map keys with `@` in FQNs also warn under Redocly naming rules; the hard failures that forced skips are the struct errors.

| Case | Target | Why skipped |
|------|--------|-------------|
| `hr_integration` | `openapi` | `$decorators` and invalid schema nesting fail OpenAPI struct validation |
| `model-base` | `openapi` | `$decorators` fail OpenAPI struct validation |
| `agreement` | `openapi` | `$decorators` fail OpenAPI struct validation |

Cases that still run for OpenAPI (for example `metamodel`, `hr_base`, `stringlength`, `circular`) lint clean under the current minimal Redocly config.

#### Unrelated existing skips (unchanged intent)

Other skips already present for protobuf, graphql, rust, java, and csharp remain; this PR does not change their meaning. New `avro` / `openapi` entries were added alongside them where needed.

### Flags
- XML Schema local tests require `xmllint` (libxml2). Without it, those tests are pending rather than failing.
- Avro local tests require a JRE. The tools jar is downloaded automatically like Jackson annotations for Java verification.
- OpenAPI local tests use `@redocly/cli` from `devDependencies`; Docker still installs it globally in the target image.
- Docker images download remote assets at build time (W3C `XMLSchema.xsd`, Maven/Apache `avro-tools`, npm `@redocly/cli`).
- Skipped case and target pairs should be revisited when `AvroVisitor` sanitizes versioned namespaces and when OpenAPI generation stops emitting non OAS `$decorators` (or maps them to `x-` extensions).

### Screenshots or Video

N/A. Verification is exercised via Mocha (`npm run test:verify`) and Docker (`npm run verify:docker:xmlschema`, `verify:docker:openapi`, `verify:docker:avro`).

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
